### PR TITLE
added iPython notebook explaining how variability works

### DIFF
--- a/examples/tutorials/VaraibilityModelExamples.ipynb
+++ b/examples/tutorials/VaraibilityModelExamples.ipynb
@@ -32,7 +32,9 @@
     "\n",
     "`sims_catUtils/python/lsst/sims/catUtils/baseCatalogModels`\n",
     "\n",
-    "The class for accessing the table of RR Lyrae can be imported like so:"
+    "The class for accessing the table of RR Lyrae can be imported like so:\n",
+    "\n",
+    "<b>Note:</b> These next two cells are going to generate warnings.  They are harmless.  We are working to fix them."
    ]
   },
   {
@@ -61,7 +63,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We now have a connection to the table of RR Lyrae.  This table contains information such as the position and velocity of each RR Lyrae in our model Milky Way.  It also contains names associating each RR Lyra with a spectrum in `sims_sed_library`.  The mixin `PhotometryStars` allows us to integrate those spectra over the LSST bandpasses and produce magnitudes.\n",
+    "We now have a connection to the table of RR Lyrae.  This table contains information such as the position and velocity of each RR Lyra in our model Milky Way.  It also contains names associating each RR Lyra with a spectrum in `sims_sed_library`.  The mixin `PhotometryStars` allows us to integrate those spectra over the LSST bandpasses and produce magnitudes.\n",
     "\n",
     "Below, we create a catalog of RR Lyrae and their magnitudes in the u band, outputting our catalog to the text file `baseline_catalog.txt`.\n",
     "\n",
@@ -69,7 +71,7 @@
     "\n",
     "`sims_catUtils/examples/tutorials/`\n",
     "\n",
-    "as well as in the notebookd\n",
+    "as well as in the notebook\n",
     "\n",
     "`CatSim/CatsimTutorial_SimulationsAHM_1503.ipynb`\n",
     "\n",
@@ -101,7 +103,6 @@
    },
    "outputs": [],
    "source": [
-    "\n",
     "class uMagBaselineClass(InstanceCatalog, PhotometryStars):\n",
     "    column_outputs = ['uniqueId', 'raJ2000', 'decJ2000', 'lsst_u']\n",
     "    transformations = {'raJ2000':numpy.degrees, 'decJ2000':numpy.degrees}"
@@ -168,7 +169,7 @@
    "source": [
     "Variability is controlled by the mixins `VariabilityStars` and `VariabilityGalaxies`.  These mixins calculate columns `delta_lsst_u`, `delta_lsst_g`, `delta_lsst_r`, etc. and automatically add them to the baseline magnitude columns.\n",
     "\n",
-    "Below, we take the same telescope pointing, but turn on variability and calculate the magnitudes.  Compare the output below to the output frome the baseline catalog above.  Note that we have output the `delta_lsst_u` column as well for comparison."
+    "Below, we take the same telescope pointing, but turn on variability and calculate the magnitudes.  Compare the output below to the output from the baseline catalog above.  Note that we have output the `delta_lsst_u` column as well for comparison."
    ]
   },
   {
@@ -193,7 +194,10 @@
     "class uMagVarClass(InstanceCatalog, PhotometryStars, VariabilityStars):\n",
     "    column_outputs = ['uniqueId', \n",
     "                      'raJ2000', 'decJ2000', \n",
-    "                      'lsst_u', 'delta_lsst_u']"
+    "                      'lsst_u', 'delta_lsst_u']\n",
+    "    \n",
+    "    transformations = {'raJ2000':numpy.degrees,\n",
+    "                       'decJ2000':numpy.degrees}"
    ]
   },
   {

--- a/examples/tutorials/VaraibilityModelExamples.ipynb
+++ b/examples/tutorials/VaraibilityModelExamples.ipynb
@@ -1,0 +1,302 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The database hosted by the University of Washington (on a machine named 'fatboy'; it seems very likely that I will refer to the database by this name for the rest of this notebook) is sub-divided into tables with each table corresponding to a type of astronomical object (main sequence star, white dwarf, galaxy, etc.).  While some tables represent a union of disparate objects (starsALL is the union of main sequence, RGB, white dwarf, RRLyrae, and blue horizontal branch stars), most of the objects in the database are segregated.  This is relevant, because each class of variable object has its own table.  There are separate tables for Cepheids, RR Lyrae, white dwarfs, and eclipsing binary stars.\n",
+    "\n",
+    "A full list of tables on fatboy can be found here:\n",
+    "\n",
+    "https://confluence.lsstcorp.org/display/SIM/Database+Schema\n",
+    "\n",
+    "Currently, only the tables which are incorporated into starsALL are believed to have a realistic distribution, and even that is only over the LSST survey footprint (no guarantees are made for the northern sky)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will use the table of RR Lyrae as an example to explain how variability works in CatSim."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As described in the example notebook\n",
+    "\n",
+    "`sims_catUtils/examples/tutorials/reading_in_custom_data.ipynb`\n",
+    "\n",
+    "fatboy database tables are accessed through python classes that are daughter classes of `CatalogDBObject`.  Many of these classes are already defined in \n",
+    "\n",
+    "`sims_catUtils/python/lsst/sims/catUtils/baseCatalogModels`\n",
+    "\n",
+    "The class for accessing the table of RR Lyrae can be imported like so:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from lsst.sims.catUtils.baseCatalogModels import RRLyStarObj"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "rrlyDB = RRLyStarObj()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We now have a connection to the table of RR Lyrae.  This table contains information such as the position and velocity of each RR Lyrae in our model Milky Way.  It also contains names associating each RR Lyra with a spectrum in `sims_sed_library`.  The mixin `PhotometryStars` allows us to integrate those spectra over the LSST bandpasses and produce magnitudes.\n",
+    "\n",
+    "Below, we create a catalog of RR Lyrae and their magnitudes in the u band, outputting our catalog to the text file `baseline_catalog.txt`.\n",
+    "\n",
+    "A more general and detailed description of this process can be found in the iPython notebooks in\n",
+    "\n",
+    "`sims_catUtils/examples/tutorials/`\n",
+    "\n",
+    "as well as in the notebookd\n",
+    "\n",
+    "`CatSim/CatsimTutorial_SimulationsAHM_1503.ipynb`\n",
+    "\n",
+    "in the GitHub repository\n",
+    "\n",
+    "https://github.com/uwssg/LSST-Tutorials\n",
+    "\n",
+    "<b>Note:</b> Every time a daughter class of `InstanceCatalog` is created, it is added to a registry of such classes.  This registry does not allow duplicate entries, so running the cell below that declares `uMagBaselineClass` (or any cell that declares a daughter class of `InstanceCatalog`) will raise an exception.  If you find yourself needing to run the declaration cell below more than once, you will need to restart your kernel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import numpy\n",
+    "from lsst.sims.catalogs.measures.instance import InstanceCatalog\n",
+    "from lsst.sims.catUtils.mixins import PhotometryStars"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "class uMagBaselineClass(InstanceCatalog, PhotometryStars):\n",
+    "    column_outputs = ['uniqueId', 'raJ2000', 'decJ2000', 'lsst_u']\n",
+    "    transformations = {'raJ2000':numpy.degrees, 'decJ2000':numpy.degrees}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from lsst.sims.utils import ObservationMetaData"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "#specify the telescope pointing\n",
+    "obs = ObservationMetaData(unrefractedRA=0.0, unrefractedDec=0.0,\n",
+    "                          boundType='circle', boundLength=2.0,\n",
+    "                          mjd=52350.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "baselineCat = uMagBaselineClass(rrlyDB, obs_metadata=obs)\n",
+    "baselineCat.write_catalog('baseline_catalog.txt')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we will print out our catalog to the notebook"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "!cat baseline_catalog.txt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Variability is controlled by the mixins `VariabilityStars` and `VariabilityGalaxies`.  These mixins calculate columns `delta_lsst_u`, `delta_lsst_g`, `delta_lsst_r`, etc. and automatically add them to the baseline magnitude columns.\n",
+    "\n",
+    "Below, we take the same telescope pointing, but turn on variability and calculate the magnitudes.  Compare the output below to the output frome the baseline catalog above.  Note that we have output the `delta_lsst_u` column as well for comparison."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from lsst.sims.catUtils.mixins import VariabilityStars"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "class uMagVarClass(InstanceCatalog, PhotometryStars, VariabilityStars):\n",
+    "    column_outputs = ['uniqueId', \n",
+    "                      'raJ2000', 'decJ2000', \n",
+    "                      'lsst_u', 'delta_lsst_u']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "varCat = uMagVarClass(rrlyDB, obs_metadata=obs)\n",
+    "varCat.write_catalog('var_catalog.txt')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "!cat var_catalog.txt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "How did `VariabilityStars` know how to calculate `delta_lsst_u`?\n",
+    "\n",
+    "Each object in the `starsRRLy` table of fatboy has a column `varParamStr` which is a json representation of a dict.  This dict contains parameters governing the variability model.  One of these parameters is `varMethodName`.  This corresponds to a method defined in\n",
+    "\n",
+    "`sims_catUtils/python/lsst/sims/catUtils/mixins/VariabilityMixin.py`\n",
+    "\n",
+    "When `delta_lsst_u` is called for, `VariabilityStars` calls that method and passes the other parameters from `varParamStr` along as arguments.  The variability method then calculates magnitude offsets in each of the LSST bands and returns them in a dict keyed to bandpass name (i.e. `['u','g','r','i','z','y']`)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the cell below, we query the `starsRRly` table directly to show what `varParamStr` looks like."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "dtype = numpy.dtype([('ra', numpy.float), ('dec', numpy.float),\n",
+    "                     ('varParamStr', str, 300)])\n",
+    "query = 'SELECT TOP 5 ra, decl, varParamStr FROM starsRRLy'\n",
+    "results = rrlyDB.execute_arbitrary(query, dtype=dtype)\n",
+    "for line in results:\n",
+    "    print line"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the case of RR Lyrae, the variability model is based on sets of six light curves (one for each LSST bandpass) stored in `sims_sed_library/rrly_lc/`.  These light curves contain `delta_[u,g,r,i,z,y]` as a function of mjd.  They are read in and interpolated (relative to the start time specified by `tStartMjd`) to determine the appropriate magnitude offset in each band.  `varParamStr` specifies which set of light curves corresponds to which specific RR Lyra with the `filename` parameter.\n",
+    "\n",
+    "Most of our variability models are based on this interpolated light curve method.  To see how each variability model is implemented, inspect\n",
+    "\n",
+    "`sims_catUtils/python/lsst/sims/catUtils/mixins/Variability.py`\n",
+    "\n",
+    "We are working to develop more physically realistic spectro-temporal models, but that is still in a very early stage."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
This pull requests adds an iPython notebook explaining how variability works in CatSim.

This is not a high priority.  Someone asked me for this at Bremerton.  I figured it should be a proper part of the catUtils package.