### PR TITLE
Bugfix/sim 1615/gamma cache

### DIFF
--- a/python/lsst/sims/catUtils/baseCatalogModels/GalaxyModels.py
+++ b/python/lsst/sims/catUtils/baseCatalogModels/GalaxyModels.py
@@ -295,7 +295,7 @@ class GalaxyBulgeObj(GalaxyTileObj):
     objectTypeId = 26
     doRunTest = True
     testObservationMetaData = ObservationMetaData(boundType='circle', pointingRA=10.0, pointingDec=-45.0,
-                                                  boundLength=0.01, mjd=53000., bandpassName='i', m5=22.0)
+                                                  boundLength=0.01, mjd=53000., bandpassName='r', m5=22.0)
     #: The following maps column names to database schema.  The tuples
     #: must be at least length 2.  If column name is the same as the name
     #: in the DB the mapping element may be None.  The rest of the tuple
@@ -334,7 +334,7 @@ class GalaxyDiskObj(GalaxyTileObj):
     objectTypeId = 27
     doRunTest = True
     testObservationMetaData = ObservationMetaData(boundType='circle', pointingRA=66.0, pointingDec=-80.0,
-                                                  boundLength=0.01, mjd=53730., bandpassName='g', m5=22.0)
+                                                  boundLength=0.01, mjd=53730., bandpassName='r', m5=22.0)
     #: The following maps column names to database schema.  The tuples
     #: must be at least length 2.  If column name is the same as the name
     #: in the DB the mapping element may be None.  The rest of the tuple
@@ -373,7 +373,7 @@ class GalaxyAgnObj(GalaxyTileObj):
     objectTypeId = 28
     doRunTest = True
     testObservationMetaData = ObservationMetaData(boundType='circle', pointingRA=234.0, pointingDec=-15.0,
-                                                  boundLength=0.01, mjd=51000., bandpassName='y', m5=22.0)
+                                                  boundLength=0.01, mjd=51000., bandpassName='r', m5=22.0)
     #: The following maps column names to database schema.  The tuples
     #: must be at least length 2.  If column name is the same as the name
     #: in the DB the mapping element may be None.  The rest of the tuple
@@ -406,7 +406,7 @@ class ImageAgnObj(BaseCatalogObj):
     objectTypeId = 29
     doRunTest = True
     #all sky since this is a small set.
-    testObservationMetaData = ObservationMetaData(mjd=53000., bandpassName='i', m5=22.0)
+    testObservationMetaData = ObservationMetaData(mjd=53000., bandpassName='r', m5=22.0)
 
     dbDefaultValues = {'varsimobjid':-1, 'myid':-1}
     #: The following maps column names to database schema.  The tuples
@@ -436,7 +436,7 @@ class LensGalaxyObj(BaseCatalogObj):
     objectTypeId = 30
     doRunTest = True
     #all sky since this is a small set.
-    testObservationMetaData = ObservationMetaData(mjd=53000., bandpassName='i', m5=22.0)
+    testObservationMetaData = ObservationMetaData(mjd=53000., bandpassName='r', m5=22.0)
 
     dbDefaultValues = {'varsimobjid':-1, 'myid':-1, 'variabilityParameters':None}
     #: The following maps column names to database schema.  The tuples

--- a/python/lsst/sims/catUtils/baseCatalogModels/StarModels.py
+++ b/python/lsst/sims/catUtils/baseCatalogModels/StarModels.py
@@ -16,7 +16,7 @@ class StarBase(BaseCatalogObj):
     #Don't run test on base class
     doRunTest = False
     #default observation metadata
-    testObservationMetaData = ObservationMetaData(boundType='circle', unrefractedRA=210.0, unrefractedDec=-30.0,
+    testObservationMetaData = ObservationMetaData(boundType='circle', pointingRA=210.0, pointingDec=-30.0,
                                                   boundLength=0.3, mjd=52000., bandpassName='r',m5=22.0)
     dbDefaultValues = {'varsimobjid':-1, 'runid':-1, 'ismultiple':-1, 'run':-1,
                        'runobjid':-1}

--- a/python/lsst/sims/catUtils/baseCatalogModels/StarModels.py
+++ b/python/lsst/sims/catUtils/baseCatalogModels/StarModels.py
@@ -16,8 +16,8 @@ class StarBase(BaseCatalogObj):
     #Don't run test on base class
     doRunTest = False
     #default observation metadata
-    testObservationMetaData = ObservationMetaData(boundType='circle', pointingRA=210.0, pointingDec=-30.0,
-                                                  boundLength=0.3, mjd=52000., bandpassName='g',m5=22.0)
+    testObservationMetaData = ObservationMetaData(boundType='circle', unrefractedRA=210.0, unrefractedDec=-30.0,
+                                                  boundLength=0.3, mjd=52000., bandpassName='r',m5=22.0)
     dbDefaultValues = {'varsimobjid':-1, 'runid':-1, 'ismultiple':-1, 'run':-1,
                        'runobjid':-1}
     #These types should be matched to the database.
@@ -43,7 +43,7 @@ class StarObj(StarBase):
     objectTypeId = 4
     doRunTest = True
     testObservationMetaData = ObservationMetaData(boundType = 'circle', pointingRA=210.0, pointingDec=-30.0,
-                                                  boundLength=0.1, mjd=52000., bandpassName='g', m5=22.0)
+                                                  boundLength=0.1, mjd=52000., bandpassName='r', m5=22.0)
     #These types should be matched to the database.
     #: Default map is float.  If the column mapping is the same as the column name, None can be specified
     columns = [('id','simobjid', int),
@@ -66,7 +66,7 @@ class MsStarObj(StarBase):
     objectTypeId = 5
     doRunTest = True
     testObservationMetaData = ObservationMetaData(boundType = 'circle', pointingRA=210.0, pointingDec=-30.0,
-                                                  boundLength=0.1, mjd=52000., bandpassName='g',m5=22.0)
+                                                  boundLength=0.1, mjd=52000., bandpassName='r',m5=22.0)
     #These types should be matched to the database.
     #: Default map is float.  If the column mapping is the same as the column name, None can be specified
     columns = [('id','simobjid', int),
@@ -151,7 +151,7 @@ class EbStarObj(StarBase):
     tableid = 'ebstars'
     objectTypeId = 9
     doRunTest = True
-    testObservationMetaData = ObservationMetaData(mjd=52000., bandpassName='g', m5=22.0)
+    testObservationMetaData = ObservationMetaData(mjd=52000., bandpassName='r', m5=22.0)
     #These types should be matched to the database.
     #: Default map is float.  If the column mapping is the same as the column name, None can be specified
     columns = [('id','simobjid', int),
@@ -173,7 +173,7 @@ class CepheidStarObj(StarBase):
     tableid = 'cepheidstars'
     objectTypeId = 10
     doRunTest = True
-    testObservationMetaData = ObservationMetaData(mjd=52000., bandpassName='g', m5=22.0)
+    testObservationMetaData = ObservationMetaData(mjd=52000., bandpassName='r', m5=22.0)
     #These types should be matched to the database.
     #: Default map is float.  If the column mapping is the same as the column name, None can be specified
     columns = [('id','simobjid', int),
@@ -195,7 +195,7 @@ class EasterEggStarObj(StarBase):
     tableid = 'AstromEasterEggs'
     objectTypeId = 11
     doRunTest = True
-    testObservationMetaData = ObservationMetaData(mjd=52000., bandpassName='g', m5=22.0)
+    testObservationMetaData = ObservationMetaData(mjd=52000., bandpassName='r', m5=22.0)
     dbDefaultValues = StarBase.dbDefaultValues
     dbDefaultValues['sedid']=-1
     dbDefaultValues['especid']=-1
@@ -224,7 +224,7 @@ class DwarfGalStarObj(StarBase):
     objectTypeId = 12
     doRunTest = True
     testObservationMetaData = ObservationMetaData(boundType='circle', pointingRA=2.58, pointingDec=-0.77,
-                                                  boundLength=0.1, mjd=52000., bandpassName='g', m5=22.0)
+                                                  boundLength=0.1, mjd=52000., bandpassName='r', m5=22.0)
     #These types should be matched to the database.
     #: Default map is float.  If the column mapping is the same as the column name, None can be specified
     columns = [('id','simobjid', int),

--- a/python/lsst/sims/catUtils/exampleCatalogDefinitions/obsCatalogExamples.py
+++ b/python/lsst/sims/catUtils/exampleCatalogDefinitions/obsCatalogExamples.py
@@ -11,9 +11,7 @@ class ObsStarCatalogBase(InstanceCatalog, AstrometryStars, PhotometryStars, Came
     comment_char = ''
     camera = loadCamera(lsst.utils.getPackageDir('obs_lsstSim'))
     catalog_type = 'obs_star_cat'
-    column_outputs = ['uniqueId', 'raObserved', 'decObserved', 'lsst_u', 'sigma_lsst_u',
-                      'lsst_g', 'sigma_lsst_g', 'lsst_r', 'sigma_lsst_r', 'lsst_i',
-                      'sigma_lsst_i', 'lsst_z', 'sigma_lsst_z', 'lsst_y', 'sigma_lsst_y',
+    column_outputs = ['uniqueId', 'raObserved', 'decObserved', 'lsst_r', 'sigma_lsst_r',
                       'chipName', 'xPix', 'yPix']
     default_formats = {'S':'%s', 'f':'%.8f', 'i':'%i'}
     transformations = {'raObserved':numpy.degrees, 'decObserved':numpy.degrees}

--- a/python/lsst/sims/catUtils/mixins/PhotometryMixin.py
+++ b/python/lsst/sims/catUtils/mixins/PhotometryMixin.py
@@ -73,7 +73,7 @@ class PhotometryBase(object):
 
         @param [in] m5_names are the keys to the self.obs_metadata.m5 dict
         corresponding to the bandpasses in column_names (e.g. in the case
-        of galaxies, the magntiude columns
+        of galaxies, the magnitude columns
 
         column_names = ['uBulge', 'gBulge', 'rBulge', 'iBulge', 'zBulge', 'yBulge']
 

--- a/python/lsst/sims/catUtils/mixins/PhotometryMixin.py
+++ b/python/lsst/sims/catUtils/mixins/PhotometryMixin.py
@@ -117,8 +117,9 @@ class PhotometryBase(object):
                                     for mname, name in zip(m5_names, column_names)]
                                    ).transpose()
         except KeyError as kk:
-            print 'You got the KeyError: ',kk.args[0]
-            raise KeyError('Is it possible your ObservationMetaData does not have the proper\n'
+            msg = 'You got the KeyError: %s' % kk.args[0]
+            raise KeyError('%s \n' % msg \
+                           + 'Is it possible your ObservationMetaData does not have the proper\n'
                            'm5 values defined?')
 
 

--- a/python/lsst/sims/catUtils/mixins/PhotometryMixin.py
+++ b/python/lsst/sims/catUtils/mixins/PhotometryMixin.py
@@ -38,66 +38,29 @@ class PhotometryBase(object):
     #defaults to LSST values
     photParams = PhotometricParameters()
 
-    def calculateMagnitudeUncertainty(self, magnitudes, bandpassDict, obs_metadata=None):
+
+    def _cacheGamma(self, m5_names, bandpassDict):
         """
-        Calculate the uncertainty in magnitudes using the model from equation (5) of arXiv:0805.2366
+        Generate or populate the cache of gamma values used by this InstanceCatalog
+        to calculate photometric uncertainties (gamma is defined in equation 5 of
+        the LSST overview paper arXiv:0805.2366)
 
-        @param [in] magnitudes is a numpy array containing the object magnitudes.  Every row corresponds to
-        a bandpass, which is to say that magnitudes[i][j] is the magnitude of the jth object in the
-        bandpass characterized by self.bandpassDict.values()[i]
+        @param [in] m5_names is a list of the names of keys by which m5 values are
+        referred to in the dict self.obs_metadata.m5
 
-        @param [in] bandpassDict is a BandpassDict characterizing the bandpasses being used
-
-        @param [in] obs_metadata is the metadata of this observation (mostly desired because
-        it will contain information about m5, the magnitude at which objects are detected
-        at the 5-sigma limit in each bandpass)
-
-        @param [out] a 1-dimensional numpy array containing the magntiude uncertainty
-        corresponding to the magnitudes passed into this method.
+        @param [in] bandpassDict is the bandpassDict containing the bandpasses
+        corresponding to those m5 values.
         """
 
-        if obs_metadata is None:
-            raise RuntimeError("Need to pass an ObservationMetaData into calculatePhotometricUncertainty")
+        if not hasattr(self, '_gamma_cache'):
+            self._gamma_cache = {}
 
-        if magnitudes.shape[0] != len(bandpassDict):
-            raise RuntimeError("Passed %d magnitudes to " % magnitudes.shape[0] + \
-                                " PhotometryBase.calculatePhotometricUncertainty; " + \
-                                "needed %d " % len(bandpassDict))
-
-        #if we have not run this method before, calculate and cache the m5 and gamma parameter
-        #values (see eqn 5 of arXiv:0805.2366) for future use
-        m5Defaults = None
-
-        if not hasattr(self, '_gammaList') or \
-        len(self._gammaList) != len(bandpassDict):
-
-            mm = []
-            gg = []
-            for b in bandpassDict.keys():
-                if b in obs_metadata.m5:
-                    mm.append(obs_metadata.m5[b])
-                    gg.append(calcGamma(bandpassDict[b], obs_metadata.m5[b],
-                              photParams=self.photParams))
-                else:
-                    if m5Defaults is None:
-                        m5Defaults = LSSTdefaults()
-
-                    try:
-                        mm.append(m5Defaults.m5(b))
-                        gg.append(m5Defaults.gamma(b))
-                    except:
-                        raise RuntimeError("No way to calculate gamma or m5 for filter %s " % b)
-
-            self._m5List = numpy.array(mm)
-            self._gammaList = numpy.array(gg)
-
-        error = calcMagError_m5(magnitudes, bandpassDict.values(), self._m5List,
-                                gamma=self._gammaList, photParams=self.photParams)
-
-        return error
+        for mm, bp in zip(m5_names, bandpassDict.values()):
+            if mm not in self._gamma_cache and mm in self.obs_metadata.m5:
+                self._gamma_cache[mm] = calcGamma(bp, self.obs_metadata.m5[mm], photParams=self.photParams)
 
 
-    def _magnitudeUncertaintyGetter(self, column_names, bandpassDict_name):
+    def _magnitudeUncertaintyGetter(self, column_names, m5_names, bandpassDict_name):
         """
         Generic getter for magnitude uncertainty columns.
 
@@ -107,6 +70,16 @@ class PhotometryBase(object):
         @param [in] column_names is the list of magnitude column names
         associated with the uncertainties calculated by this getter
         (the 'xx' in the 'sigma_xx' above)
+
+        @param [in] m5_names are the keys to the self.obs_metadata.m5 dict
+        corresponding to the bandpasses in column_names (e.g. in the case
+        of galaxies, the magntiude columns
+
+        column_names = ['uBulge', 'gBulge', 'rBulge', 'iBulge', 'zBulge', 'yBulge']
+
+        may correspond to m5 values keyed to
+
+        m5_names = ['u', 'g', 'r', 'i', 'z', 'y'])
 
         @param [in] bandpassDict_name is a string indicating the name of
         the InstanceCatalog member variable containing the BandpassDict
@@ -128,12 +101,29 @@ class PhotometryBase(object):
                 if num_elements is None:
                     num_elements = len(ref)
 
+        bandpassDict = getattr(self, bandpassDict_name)
+
+        self._cacheGamma(m5_names, bandpassDict)
+
         magnitudes = numpy.array([self.column_by_name(name) if name in self._actually_calculated_columns
                                   else [numpy.NaN]*num_elements
                                   for name in column_names])
 
-        return self.calculateMagnitudeUncertainty(magnitudes, getattr(self, bandpassDict_name),
-                                                  obs_metadata=self.obs_metadata)
+        try:
+            param_arr = numpy.array(
+                                    [[self.obs_metadata.m5[mname], self._gamma_cache[mname]]
+                                    if name in self._actually_calculated_columns
+                                    else [numpy.NaN, numpy.NaN]
+                                    for mname, name in zip(m5_names, column_names)]
+                                   ).transpose()
+        except KeyError as kk:
+            print 'You got the KeyError: ',kk.args[0]
+            raise KeyError('Is it possible your ObservationMetaData does not have the proper\n'
+                           'm5 values defined?')
+
+
+        return calcMagError_m5(magnitudes, bandpassDict.values(), param_arr[0], self.photParams,
+                               gamma=param_arr[1])
 
 
     @compound('sigma_lsst_u','sigma_lsst_g','sigma_lsst_r','sigma_lsst_i',
@@ -145,6 +135,7 @@ class PhotometryBase(object):
 
         return self._magnitudeUncertaintyGetter(['lsst_u', 'lsst_g', 'lsst_r',
                                                  'lsst_i', 'lsst_z', 'lsst_y'],
+                                                ['u', 'g', 'r', 'i', 'z', 'y'],
                                                  'lsstBandpassDict')
 
 
@@ -449,6 +440,7 @@ class PhotometryGalaxies(PhotometryBase):
 
         return self._magnitudeUncertaintyGetter(['uBulge', 'gBulge', 'rBulge',
                                                 'iBulge', 'zBulge', 'yBulge'],
+                                                ['u', 'g', 'r', 'i', 'z', 'y'],
                                                 'lsstBandpassDict')
 
 
@@ -461,6 +453,7 @@ class PhotometryGalaxies(PhotometryBase):
 
         return self._magnitudeUncertaintyGetter(['uDisk', 'gDisk', 'rDisk',
                                                 'iDisk', 'zDisk', 'yDisk'],
+                                                ['u', 'g', 'r', 'i', 'z', 'y'],
                                                 'lsstBandpassDict')
 
 
@@ -473,6 +466,7 @@ class PhotometryGalaxies(PhotometryBase):
 
         return self._magnitudeUncertaintyGetter(['uAgn', 'gAgn', 'rAgn',
                                                 'iAgn', 'zAgn', 'yAgn'],
+                                                ['u', 'g', 'r', 'i', 'z', 'y'],
                                                 'lsstBandpassDict')
 
 

--- a/tests/testArbitraryUncertaintyGetters.py
+++ b/tests/testArbitraryUncertaintyGetters.py
@@ -13,11 +13,11 @@ from lsst.sims.photUtils import BandpassDict, Bandpass, Sed, PhotometricParamete
 
 class PhotometryCartoon(object):
 
-    @compound('cartoon_u', 'cartoon_g')
+    @compound('cartoon_u', 'cartoon_g', 'cartoon_r', 'cartoon_i', 'cartoon_z')
     def get_cartoon_mags(self):
         if not hasattr(self, 'cartoonBandpassDict'):
             self.cartoonBandpassDict = BandpassDict.loadTotalBandpassesFromFiles(
-                                                     bandpassNames = ['u', 'g'],
+                                                     bandpassNames = ['u', 'g', 'r', 'i', 'z'],
                                                      bandpassDir = os.path.join(getPackageDir('sims_photUtils'), 'tests',
                                                                                'cartoonSedTestData'),
                                                      bandpassRoot = 'test_bandpass_'
@@ -26,9 +26,11 @@ class PhotometryCartoon(object):
         return self._magnitudeGetter(self.cartoonBandpassDict, self.get_cartoon_mags._colnames)
 
 
-    @compound('sigma_cartoon_u', 'sigma_cartoon_g')
+    @compound('sigma_cartoon_u', 'sigma_cartoon_g', 'sigma_cartoon_r', 'sigma_cartoon_i', 'sigma_cartoon_z')
     def get_cartoon_uncertainty(self):
-        return self._magnitudeUncertaintyGetter(['cartoon_u', 'cartoon_g'], 'cartoonBandpassDict')
+        return self._magnitudeUncertaintyGetter(['cartoon_u', 'cartoon_g', 'cartoon_r', 'cartoon_i', 'cartoon_z'],
+                                                ['u', 'g', 'r', 'i', 'z', 'y'],
+                                                 'cartoonBandpassDict')
 
 
 class CartoonStars(InstanceCatalog, PhotometryStars, PhotometryCartoon):

--- a/tests/testArbitraryUncertaintyGetters.py
+++ b/tests/testArbitraryUncertaintyGetters.py
@@ -29,7 +29,7 @@ class PhotometryCartoon(object):
     @compound('sigma_cartoon_u', 'sigma_cartoon_g', 'sigma_cartoon_r', 'sigma_cartoon_i', 'sigma_cartoon_z')
     def get_cartoon_uncertainty(self):
         return self._magnitudeUncertaintyGetter(['cartoon_u', 'cartoon_g', 'cartoon_r', 'cartoon_i', 'cartoon_z'],
-                                                ['u', 'g', 'r', 'i', 'z', 'y'],
+                                                ['c_u', 'c_g', 'c_r', 'c_i', 'c_z', 'c_y'],
                                                  'cartoonBandpassDict')
 
 
@@ -55,7 +55,7 @@ class CartoonUncertaintyTestCase(unittest.TestCase):
         self.gband.readThroughput(os.path.join(getPackageDir('sims_photUtils'), 'tests', 'cartoonSedTestData', 'test_bandpass_g.dat'))
 
     def test_stars(self):
-        obs = ObservationMetaData(bandpassName=['u', 'g'],
+        obs = ObservationMetaData(bandpassName=['c_u', 'c_g'],
                                   m5=[25.0, 26.0])
         db_dtype = np.dtype([
                            ('id', np.int),
@@ -95,9 +95,80 @@ class CartoonUncertaintyTestCase(unittest.TestCase):
             self.assertAlmostEqual(umag, controlData['cartoon_u'][ix], 10)
             gmag = spectrum.calcMag(self.gband)
             self.assertAlmostEqual(gmag, controlData['cartoon_g'][ix], 10)
-            magError = calcMagError_m5(np.array([umag, gmag]), [self.uband, self.gband], [obs.m5['u'], obs.m5['g']], PhotometricParameters())
+            magError = calcMagError_m5(np.array([umag, gmag]), [self.uband, self.gband], [obs.m5['c_u'], obs.m5['c_g']], PhotometricParameters())
             self.assertAlmostEqual(magError[0], controlData['sigma_cartoon_u'][ix], 10)
             self.assertAlmostEqual(magError[1], controlData['sigma_cartoon_g'][ix], 10)
+
+
+    def test_mixed_stars(self):
+        """
+        Here we will test the (somewhat absurd) case of a catalog with two different bandpasses
+        (lsst_ and cartoon_) in order to verify that gamma values are being cached correctly
+        """
+
+        lsst_u_band = Bandpass()
+        lsst_u_band.readThroughput(os.path.join(getPackageDir('throughputs'), 'baseline', 'total_u.dat'))
+        lsst_g_band = Bandpass()
+        lsst_g_band.readThroughput(os.path.join(getPackageDir('throughputs'), 'baseline', 'total_g.dat'))
+
+        obs = ObservationMetaData(bandpassName=['c_u', 'c_g', 'u', 'g'],
+                                  m5=[25.0, 26.0, 15.0, 16.0])
+        # make the difference in m5 between the two bandpass systems extreme
+        # so that, in the unit test, we can be sure that the correct values
+        # are being used for the correct getters
+
+        db_dtype = np.dtype([
+                           ('id', np.int),
+                           ('raJ2000', np.float),
+                           ('decJ2000', np.float),
+                           ('sedFilename', str, 100),
+                           ('magNorm', np.float),
+                           ('galacticAv', np.float)
+                           ])
+
+        inputDir = os.path.join(getPackageDir('sims_catUtils'), 'tests', 'testData')
+        inputFile = os.path.join(inputDir, 'IndicesTestCatalogStars.txt')
+        db = fileDBObject(inputFile, dtype=db_dtype, runtable='test', idColKey='id')
+        catName = os.path.join(getPackageDir('sims_catUtils'), 'tests', 'scratchSpace', 'cartoonStarCat.txt')
+        cat = CartoonStars(db, obs_metadata=obs, column_outputs=['lsst_u', 'lsst_g', 'sigma_lsst_u', 'sigma_lsst_g'])
+        cat.write_catalog(catName)
+
+        dtype = np.dtype([(name, np.float) for name in cat._column_outputs])
+
+        controlData = np.genfromtxt(catName, dtype=dtype, delimiter=',')
+
+        if os.path.exists(catName):
+            os.unlink(catName)
+
+        db_columns = db.query_columns(['id', 'raJ2000', 'decJ2000', 'sedFilename', 'magNorm', 'galacticAv'])
+
+        sedDir = os.path.join(getPackageDir('sims_sed_library'), 'starSED', 'kurucz')
+
+        for ix, line in enumerate(db_columns.next()):
+            spectrum = Sed()
+            spectrum.readSED_flambda(os.path.join(sedDir, line[3]))
+            fnorm = spectrum.calcFluxNorm(line[4], self.normband)
+            spectrum.multiplyFluxNorm(fnorm)
+            a_x, b_x = spectrum.setupCCMab()
+            spectrum.addCCMDust(a_x, b_x, A_v=line[5])
+            umag = spectrum.calcMag(self.uband)
+            self.assertAlmostEqual(umag, controlData['cartoon_u'][ix], 10)
+            gmag = spectrum.calcMag(self.gband)
+            self.assertAlmostEqual(gmag, controlData['cartoon_g'][ix], 10)
+            lsst_umag = spectrum.calcMag(lsst_u_band)
+            self.assertAlmostEqual(lsst_umag, controlData['lsst_u'][ix], 10)
+            lsst_gmag = spectrum.calcMag(lsst_g_band)
+            self.assertAlmostEqual(lsst_gmag, controlData['lsst_g'][ix], 10)
+            magError = calcMagError_m5(np.array([umag, gmag]), [self.uband, self.gband], [obs.m5['c_u'], obs.m5['c_g']], PhotometricParameters())
+            self.assertAlmostEqual(magError[0], controlData['sigma_cartoon_u'][ix], 10)
+            self.assertAlmostEqual(magError[1], controlData['sigma_cartoon_g'][ix], 10)
+            lsst_magError = calcMagError_m5(np.array([lsst_umag, lsst_gmag]), [lsst_u_band, lsst_g_band],
+                                            [obs.m5['u'], obs.m5['g']], PhotometricParameters())
+
+            self.assertAlmostEqual(lsst_magError[0], controlData['sigma_lsst_u'][ix], 10)
+            self.assertAlmostEqual(lsst_magError[1], controlData['sigma_lsst_g'][ix], 10)
+            self.assertGreater(np.abs(lsst_magError[0]-magError[0]), 0.01)
+            self.assertGreater(np.abs(lsst_magError[1]-magError[1]), 0.01)
 
 
 def suite():

--- a/tests/testPhotometryMixins.py
+++ b/tests/testPhotometryMixins.py
@@ -100,7 +100,7 @@ class photometryUnitTest(unittest.TestCase):
         self.obs_metadata = ObservationMetaData(mjd=52000.7,
                             bandpassName=bandpassName,
                             m5=[defaults.m5(mm) for mm in bandpassName],
-                            boundType='circle',unrefractedRA=200.0,unrefractedDec=-30.0,
+                            boundType='circle',pointingRA=200.0,pointingDec=-30.0,
                             boundLength=1.0)
 
         self.galaxy = myTestGals(database='PhotometryTestDatabase.db')
@@ -157,13 +157,14 @@ class photometryUnitTest(unittest.TestCase):
         uncertainty but do not define the required m5 value
         """
 
-        catName = os.path.join(lsst.utils.getPackageDir('sims_catUtils'), 'tests', 'scratchSpace',
+        catName = os.path.join(getPackageDir('sims_catUtils'), 'tests', 'scratchSpace',
                                'm5_exception_cat.txt')
 
-        obs = ObservationMetaData(unrefractedRA=25.0, unrefractedDec=-14.0,
+        obs = ObservationMetaData(pointingRA=25.0, pointingDec=-14.0,
                                   boundType='circle', boundLength=0.1,
                                   bandpassName=['u', 'g', 'r', 'z', 'y'],
-                                  m5 = [24.0] * 5)
+                                  m5 = [24.0] * 5,
+                                  mjd=57388.0)
 
         with self.assertRaises(KeyError) as context:
             cat = testStars(self.star, obs_metadata=obs)

--- a/tests/testPhotometryMixins.py
+++ b/tests/testPhotometryMixins.py
@@ -150,6 +150,40 @@ class photometryUnitTest(unittest.TestCase):
         if os.path.exists(catName):
             os.unlink(catName)
 
+
+    def test_m5_exceptions(self):
+        """
+        Test that the correct exception is raised when you ask for a photometric
+        uncertainty but do not define the required m5 value
+        """
+
+        catName = os.path.join(lsst.utils.getPackageDir('sims_catUtils'), 'tests', 'scratchSpace',
+                               'm5_exception_cat.txt')
+
+        obs = ObservationMetaData(unrefractedRA=25.0, unrefractedDec=-14.0,
+                                  boundType='circle', boundLength=0.1,
+                                  bandpassName=['u', 'g', 'r', 'z', 'y'],
+                                  m5 = [24.0] * 5)
+
+        with self.assertRaises(KeyError) as context:
+            cat = testStars(self.star, obs_metadata=obs)
+            cat.write_catalog(catName)
+
+        self.assertIn('Is it possible your ObservationMetaData does not have the proper\nm5 values defined?',
+                      context.exception.args[0])
+
+
+        with self.assertRaises(KeyError) as context:
+            cat = testGalaxies(self.galaxy, obs_metadata=obs)
+            cat.write_catalog(catName)
+
+        self.assertIn('Is it possible your ObservationMetaData does not have the proper\nm5 values defined?',
+                      context.exception.args[0])
+
+        if os.path.exists(catName):
+            os.unlink(catName)
+
+
     def testSumMagnitudes(self):
         """
         Test that the method sum_magnitudes in PhotometryGalaxies handles

--- a/tests/testSetupRoutines.py
+++ b/tests/testSetupRoutines.py
@@ -24,10 +24,7 @@ class baselineStarCatalog(InstanceCatalog, AstrometryStars, PhotometryStars):
     """
     Baseline photometry catalog against which to compare testStarCatalog
     """
-    column_outputs = ['raObserved', 'decObserved',
-                      'lsst_u', 'lsst_g', 'lsst_r', 'lsst_i', 'lsst_z', 'lsst_y',
-                      'sigma_lsst_u', 'sigma_lsst_g', 'sigma_lsst_r', 'sigma_lsst_i',
-                      'sigma_lsst_z', 'sigma_lsst_y']
+    column_outputs = ['raObserved', 'decObserved']
     default_formats = {'f':'%.12e'}
 
 class testGalaxyCatalog(InstanceCatalog, AstrometryGalaxies, PhotometryGalaxies):
@@ -42,10 +39,7 @@ class baselineGalaxyCatalog(InstanceCatalog, AstrometryGalaxies, PhotometryGalax
     """
     Baseline photometry catalog against which to compare testGalaxyCatalog
     """
-    column_outputs = ['raObserved', 'decObserved',
-                      'lsst_u', 'lsst_g', 'lsst_r', 'lsst_i', 'lsst_z', 'lsst_y',
-                      'sigma_lsst_u', 'sigma_lsst_g', 'sigma_lsst_r', 'sigma_lsst_i',
-                      'sigma_lsst_z', 'sigma_lsst_y']
+    column_outputs = ['raObserved', 'decObserved']
     default_formats = {'f':'%.12e'}
 
 class testStarDBObject(CatalogDBObject):
@@ -292,8 +286,11 @@ class InstanceCatalogSetupUnittest(unittest.TestCase):
         testCatClasses = [testStarCatalog, testGalaxyCatalog]
         testCatDBs = [self.starDBObj, self.galaxyDBObj]
         baselineCats = []
-        baselineCats.append(baselineStarCatalog(self.starDBObj, obs_metadata=self.obs_metadata))
-        baselineCats.append(baselineGalaxyCatalog(self.galaxyDBObj, obs_metadata=self.obs_metadata))
+        baselineCats.append(baselineStarCatalog(self.starDBObj, obs_metadata=self.obs_metadata_compound,
+                                                column_outputs=['lsst_g', 'sigma_lsst_g', 'lsst_i', 'sigma_lsst_i']))
+
+        baselineCats.append(baselineGalaxyCatalog(self.galaxyDBObj, obs_metadata=self.obs_metadata_compound,
+                                                  column_outputs=['lsst_g', 'sigma_lsst_g', 'lsst_i', 'sigma_lsst_i']))
 
         testName = os.path.join(getPackageDir('sims_catUtils'), 'tests', 'scratchSpace',
                                'testSetUp_testActual_testSetupCat.txt')
@@ -309,12 +306,8 @@ class InstanceCatalogSetupUnittest(unittest.TestCase):
 
 
         basedtype = numpy.dtype([('raObserved', numpy.float), ('decObserved', numpy.float),
-                                 ('lsst_u', numpy.float), ('lsst_g', numpy.float),
-                                 ('lsst_r', numpy.float), ('lsst_i', numpy.float),
-                                 ('lsst_z', numpy.float), ('lsst_y', numpy.float),
-                                 ('sigma_lsst_u', numpy.float), ('sigma_lsst_g',numpy.float),
-                                 ('sigma_lsst_r', numpy.float), ('sigma_lsst_i', numpy.float),
-                                 ('sigma_lsst_z', numpy.float), ('sigma_lsst_y', numpy.float)])
+                                 ('lsst_g', numpy.float), ('sigma_lsst_g', numpy.float),
+                                 ('lsst_i', numpy.float), ('sigma_lsst_i', numpy.float)])
 
         for (testCatClass, dbo, baselineCat, msgr) in zip(testCatClasses, testCatDBs, baselineCats, msgroot):
 
@@ -381,8 +374,11 @@ class InstanceCatalogSetupUnittest(unittest.TestCase):
         #need to set up the baseline catalogs with the compound obs_metadata so that they get the
         #correct m5 values for both magnitudes (otherwise, they will use LSST defaults, which
         #disagree with our cartoon test case)
-        baselineCats.append(baselineStarCatalog(self.starDBObj, obs_metadata=self.obs_metadata_compound))
-        baselineCats.append(baselineGalaxyCatalog(self.galaxyDBObj, obs_metadata=self.obs_metadata_compound))
+        baselineCats.append(baselineStarCatalog(self.starDBObj, obs_metadata=self.obs_metadata_compound,
+                                                column_outputs=['lsst_g', 'lsst_i', 'sigma_lsst_g', 'sigma_lsst_i']))
+
+        baselineCats.append(baselineGalaxyCatalog(self.galaxyDBObj, obs_metadata=self.obs_metadata_compound,
+                                                  column_outputs=['lsst_g', 'lsst_i', 'sigma_lsst_g', 'sigma_lsst_i']))
 
         testName = os.path.join(getPackageDir('sims_catUtils'), 'tests', 'scratchSpace',
                                 'testSetup_testSetupCatUncertainty.txt')
@@ -397,12 +393,8 @@ class InstanceCatalogSetupUnittest(unittest.TestCase):
             os.unlink(baseName)
 
         basedtype = numpy.dtype([('raObserved', numpy.float), ('decObserved', numpy.float),
-                                 ('lsst_u', numpy.float), ('lsst_g', numpy.float),
-                                 ('lsst_r', numpy.float), ('lsst_i', numpy.float),
-                                 ('lsst_z', numpy.float), ('lsst_y', numpy.float),
-                                 ('sigma_lsst_u', numpy.float), ('sigma_lsst_g',numpy.float),
-                                 ('sigma_lsst_r', numpy.float), ('sigma_lsst_i', numpy.float),
-                                 ('sigma_lsst_z', numpy.float), ('sigma_lsst_y', numpy.float)])
+                                 ('lsst_g', numpy.float), ('lsst_i', numpy.float),
+                                 ('sigma_lsst_g',numpy.float), ('sigma_lsst_i', numpy.float)])
 
         for (testCatClass, dbo, baselineCat, msgr) in zip(testCatClasses, testCatDBs, baselineCats, msgroot):
 


### PR DESCRIPTION
The magnitude uncertainty calculations in PhotometryMixins.py were caching m5 and gamma parameter values in a haphazard way.  This pull request imposes a little more control on the association between the two parameters.