### PR TITLE
Bugfix/sim 1732/mlt pho sim

### DIFF
--- a/python/lsst/sims/catUtils/exampleCatalogDefinitions/phoSimCatalogExamples.py
+++ b/python/lsst/sims/catUtils/exampleCatalogDefinitions/phoSimCatalogExamples.py
@@ -1,15 +1,23 @@
 """Instance Catalog"""
 import numpy
+from lsst.sims.utils import SpecMap, defaultSpecMap
 from lsst.sims.catalogs.measures.instance import InstanceCatalog
 from lsst.sims.utils import arcsecFromRadians
 from lsst.sims.catUtils.mixins import AstrometryStars, AstrometryGalaxies, \
                                       EBVmixin
 
 __all__ = ["PhosimInputBase", "PhoSimCatalogPoint", "PhoSimCatalogZPoint",
-           "PhoSimCatalogSersic2D"]
+           "PhoSimCatalogSersic2D", "PhoSimSpecMap"]
+
+
+PhoSimSpecMap = SpecMap(fileDict=defaultSpecMap.fileDict,
+                        dirDict={'(^lte)':'starSED/phoSimMLT'})
+
 
 class PhosimInputBase(InstanceCatalog):
     filtMap = dict([(c, i) for i,c in enumerate('ugrizy')])
+
+    specFileMap = PhoSimSpecMap
 
     cannot_be_null = ['sedFilepath']
 

--- a/tests/testPhoSimCatalogs.py
+++ b/tests/testPhoSimCatalogs.py
@@ -7,6 +7,7 @@ import numpy
 import json
 import lsst.utils
 from collections import OrderedDict
+from lsst.sims.utils import defaultSpecMap
 from lsst.sims.catalogs.measures.instance import compound, CompoundInstanceCatalog
 from lsst.sims.catUtils.utils import testStarsDBObj, testGalaxyDiskDBObj, \
                                      testGalaxyBulgeDBObj, testGalaxyAgnDBObj
@@ -54,6 +55,27 @@ class PhoSimCatalogTest(unittest.TestCase):
                 self.assertIn(control_line, lines)
 
             self.assertGreater(len(lines), len(self.control_header)+3)
+
+
+    def testSpecFileMap(self):
+        """
+        Test that the PhoSim InstanceCatalog SpecFileMaps map MLT dwarf spectra
+        to the starSED/phoSimMLT/ directory (that is where the MLT spectra which
+        have been clipped to honor PhoSim's 'no more than 24,999 lines per SED
+        file' requirement reside)
+        """
+
+        cat = PhoSimCatalogPoint(self.starDB, obs_metadata=self.obs_metadata)
+        self.assertEqual(cat.specFileMap['lte_123.txt'], 'starSED/phoSimMLT/lte_123.txt.gz')
+        self.assertEqual(cat.specFileMap['lte_123.txt.gz'], 'starSED/phoSimMLT/lte_123.txt.gz')
+        self.assertNotEqual(cat.specFileMap['lte_123.txt'], defaultSpecMap['lte_123.txt'])
+
+        # verify that the usual stellar mappings still apply
+        for test_name in ('kp_123.txt', 'km_123.txt', 'Const_123.txt', 'Exp_123.txt', 'Burst_123.txt',
+                         'bergeron_123.txt', 'burrows_123.txt', 'm1_123.txt', 'L1_123.txt', 'l1_123.txt',
+                         'Inst_123.txt'):
+
+            self.assertEqual(cat.specFileMap[test_name], defaultSpecMap[test_name])
 
 
     def testCatalog(self):


### PR DESCRIPTION
When we updated the sims_sed_library last week, the MLT dwarves were matched to SED files each with 58,500 lines in them.  PhoSim only allows SED files to have 24,999 lines in them, so I added a sub-folder to sims_sed_library/starSED/ that contains the MLT dwarf spectra clipped to meet this requirement.  I then wrote a SpecFileMap sub-class specifically for the PhoSim InstanceCatalogs so that MLT dwarf spectra names get mapped to that sub-directory.

There are pull requests in

sims_utils
sims_catalogs_measures
sims_catUtils
sims_sed_library

supporting this pull request