### PR TITLE
Fixed bug

### DIFF
--- a/python/lsst/sims/catUtils/supernovae/snUniversalRules.py
+++ b/python/lsst/sims/catUtils/supernovae/snUniversalRules.py
@@ -203,5 +203,5 @@ class SNUniverse(object):
 
             if np.abs(t0val - self.mjdobs) > self.maxTimeSNVisible:
                 t0val = self.badvalues
-            return t0val
+        return t0val
 


### PR DESCRIPTION
For cases where suppressDimSN was set to True, there was a return statement in the wrong place resulting in a bug. 
Checked on Jenkins.https://ci.lsst.codes/job/stack-os-matrix/7757/
modified:   ../supernovae/snUniversalRules.py

