### PR TITLE
Compound catalog variability quickfix

### DIFF
--- a/python/lsst/sims/catUtils/exampleCatalogDefinitions/phoSimCatalogExamples.py
+++ b/python/lsst/sims/catUtils/exampleCatalogDefinitions/phoSimCatalogExamples.py
@@ -63,10 +63,9 @@ class PhosimInputBase(InstanceCatalog):
                     varName = 'delta_lsst_' + self.obs_metadata.bandpass
 
         if varName is not None and varName in self._all_available_columns:
-            magNorm += self.column_by_name(varName)
+            magNorm_out = magNorm + self.column_by_name(varName)
 
-        return magNorm
-
+        return magNorm_out
 
     def write_header(self, file_handle):
         header_name_map = {'pointingRA': 'Unrefracted_RA', 'pointingDec': 'Unrefracted_Dec'}

--- a/python/lsst/sims/catUtils/exampleCatalogDefinitions/phoSimCatalogExamples.py
+++ b/python/lsst/sims/catUtils/exampleCatalogDefinitions/phoSimCatalogExamples.py
@@ -64,8 +64,9 @@ class PhosimInputBase(InstanceCatalog):
 
         if varName is not None and varName in self._all_available_columns:
             magNorm_out = magNorm + self.column_by_name(varName)
-
-        return magNorm_out
+            return magNorm_out
+        else:
+            return magNorm
 
     def write_header(self, file_handle):
         header_name_map = {'pointingRA': 'Unrefracted_RA', 'pointingDec': 'Unrefracted_Dec'}
@@ -142,4 +143,3 @@ class PhoSimCatalogSersic2D(PhoSimCatalogZPoint):
     spatialModel = "sersic2d"
     transformations = {'raPhoSim':numpy.degrees, 'decPhoSim':numpy.degrees, 'positionAngle':numpy.degrees,
     'majorAxis':arcsecFromRadians, 'minorAxis':arcsecFromRadians}
-


### PR DESCRIPTION
Compound Catalog DBObjects were not working with variability due to a read-only issue. This takes care of that problem.