### PR TITLE
U/danielsf/sim 1794/cherry pick

### DIFF
--- a/examples/ObservationMetaData_Generator_Example.ipynb
+++ b/examples/ObservationMetaData_Generator_Example.ipynb
@@ -1,0 +1,489 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import numpy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/rbiswas/src/LSST/sims_catalogs_generation/python/lsst/sims/catalogs/generation/db/dbConnection.py:438: UserWarning: Duplicate object type id 25 specified: \n",
+      "Output object ids may not be unique.\n",
+      "This may not be a problem if you do not want globally unique id values\n",
+      "  'want globally unique id values')\n",
+      "/Users/rbiswas/src/LSST/sims_catalogs_generation/python/lsst/sims/catalogs/generation/db/dbConnection.py:438: UserWarning: Duplicate object type id 40 specified: \n",
+      "Output object ids may not be unique.\n",
+      "This may not be a problem if you do not want globally unique id values\n",
+      "  'want globally unique id values')\n"
+     ]
+    }
+   ],
+   "source": [
+    "from lsst.sims.catUtils.utils import ObservationMetaDataGenerator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from lsst.utils import getPackageDir"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Specify the path to an OpSim database\n",
+    "dbPath = os.path.join(getPackageDir('sims_data'), 'OpSimData/opsimblitz1_1133_sqlite.db')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "gen = ObservationMetaDataGenerator(database=dbPath, driver='sqlite')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "bounds = [\n",
+    "        ('obsHistID',5973),\n",
+    "        ('expDate',1220779),\n",
+    "        ('fieldRA',numpy.degrees(1.370916)),\n",
+    "        ('fieldDec',numpy.degrees(-0.456238)),\n",
+    "        ('moonRA',numpy.degrees(2.914132)),\n",
+    "        ('moonDec',numpy.degrees(0.06305)),\n",
+    "        ('rotSkyPos',numpy.degrees(3.116656)),\n",
+    "        ('telescopeFilter','i'),\n",
+    "        ('rawSeeing',0.728562),\n",
+    "        ('seeing', 0.88911899999999999),\n",
+    "        ('sunAlt',numpy.degrees(-0.522905)),\n",
+    "        ('moonAlt',numpy.degrees(0.099096)),\n",
+    "        ('dist2Moon',numpy.degrees(1.570307)),\n",
+    "        ('moonPhase',52.2325),\n",
+    "        ('expMJD',49367.129396),\n",
+    "        ('altitude',numpy.degrees(0.781015)),\n",
+    "        ('azimuth',numpy.degrees(3.470077)),\n",
+    "        ('visitExpTime',30.0),\n",
+    "        ('airmass',1.420459),\n",
+    "        ('m5',22.815249),\n",
+    "        ('skyBrightness',19.017605)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Query the OpSim database\n",
+    "\n",
+    "We can use these to query the Opsim database and get the OpSim records. These are in the form of `numpy.recarray`s"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "OpSimRecords = gen.getOpSimRecords(fieldRA=(numpy.degrees(1.370916), numpy.degrees(1.5348635)),\n",
+    "                                     limit=20)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "On the other hand we can also get the instances of Observation Meta Data which are required to build CatSim and PhoSim Instance Catalogs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "newresults = gen.getObservationMetaData(fieldRA=(numpy.degrees(1.370916), numpy.degrees(1.5348635)),\n",
+    "                                     limit=20)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "However, if we just have OpSim records in the form of tuples, we can get instances of ObservationMetaData corresponding to them:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "record = OpSimRecords[0]\n",
+    "colnames = OpSimRecords.dtype.names"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(11, 3157, 1.532509, -0.635345, 2.451784, 0.189578, 1.645979, 'y', 0.90396, 0.986894, -0.228723, -0.205508, 1.194487, 89.122626, 49353.036546, 0.910651, 1.960608, 30.0, 1.265982, 21.06111, 17.0)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(record)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "('obsHistID', 'expDate', 'fieldRA', 'fieldDec', 'moonRA', 'moonDec', 'rotSkyPos', 'filter', 'rawSeeing', 'finSeeing', 'sunAlt', 'moonAlt', 'dist2Moon', 'moonPhase', 'expMJD', 'altitude', 'azimuth', 'visitExpTime', 'airmass', 'fiveSigmaDepth', 'filtSkyBrightness')\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(colnames)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "obsMetaData = ObservationMetaDataGenerator.ObservationMetaDataForPointing(record, \n",
+    "                                                                          OpSimColumns=colnames,\n",
+    "                                                                        columnMap=ObservationMetaDataGenerator.OpSimColumnMap('finSeeing'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'y': 21.061109999999999}"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "obsMetaData.m5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "17.0"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "obsMetaData.skyBrightness"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## This can therefore be used with other ways of getting OpSim records"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import sqlite3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "conn = sqlite3.connect(dbPath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "results = pd.read_sql_query('SELECT * FROM Summary LIMIT 5', con=conn, index_col='obsHistID').to_records()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "One problem in this is that string objects are represented as 'Object' in `pandas.DataFrame` as it does not have a string type. We can convert this in the following way"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "mytypes = []\n",
+    "for i, val in enumerate(results.dtype.descr):\n",
+    "    if val[1] == '|O':\n",
+    "        mytypes.append((val[0], '|S1'))\n",
+    "    else:\n",
+    "        mytypes.append(val)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "results = results.astype(mytypes)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "columnMap = ObservationMetaDataGenerator.OpSimColumnMap('finSeeing')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "obs_metaData = ObservationMetaDataGenerator.ObservationMetaDataForPointing(results[0], columnMap=columnMap, OpSimColumns=results.dtype.names)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "OrderedDict([('Opsim_obshistid', (1, dtype('int64'))),\n",
+       "             ('SIM_SEED', (2771, dtype('int64'))),\n",
+       "             ('pointingRA', (1.6764829999999999, dtype('float64'))),\n",
+       "             ('pointingDec', (-1.082473, dtype('float64'))),\n",
+       "             ('Opsim_moonra', (2.4506920000000001, dtype('float64'))),\n",
+       "             ('Opsim_moondec', (0.18985099999999999, dtype('float64'))),\n",
+       "             ('Opsim_rotskypos', (1.280457, dtype('float64'))),\n",
+       "             ('Opsim_filter', ('y', dtype('S1'))),\n",
+       "             ('Opsim_rawseeing', (0.77972600000000003, dtype('float64'))),\n",
+       "             ('Opsim_sunalt', (-0.20924100000000001, dtype('float64'))),\n",
+       "             ('Opsim_moonalt', (-0.22903399999999999, dtype('float64'))),\n",
+       "             ('Opsim_dist2moon', (1.4073260000000001, dtype('float64'))),\n",
+       "             ('Opsim_moonphase', (89.153486000000001, dtype('float64'))),\n",
+       "             ('Opsim_expmjd', (49353.032078999997, dtype('float64'))),\n",
+       "             ('Opsim_altitude', (0.73819100000000004, dtype('float64'))),\n",
+       "             ('Opsim_azimuth', (2.5978759999999999, dtype('float64'))),\n",
+       "             ('exptime', (30.0, dtype('float64'))),\n",
+       "             ('airmass', (1.4859990000000001, dtype('float64')))])"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "obs_metaData.phoSimMetaData"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "direct = gen.getObservationMetaDataOld(obsHistID=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "OrderedDict([('Opsim_obshistid', (1, dtype('int64'))),\n",
+       "             ('SIM_SEED', (2771, dtype('int64'))),\n",
+       "             ('pointingRA', (1.6764829999999999, dtype('float64'))),\n",
+       "             ('pointingDec', (-1.082473, dtype('float64'))),\n",
+       "             ('Opsim_moonra', (2.4506920000000001, dtype('float64'))),\n",
+       "             ('Opsim_moondec', (0.18985099999999999, dtype('float64'))),\n",
+       "             ('Opsim_rotskypos', (1.280457, dtype('float64'))),\n",
+       "             ('Opsim_filter', ('y', dtype('S1'))),\n",
+       "             ('Opsim_rawseeing', (0.77972600000000003, dtype('float64'))),\n",
+       "             ('Opsim_sunalt', (-0.20924100000000001, dtype('float64'))),\n",
+       "             ('Opsim_moonalt', (-0.22903399999999999, dtype('float64'))),\n",
+       "             ('Opsim_dist2moon', (1.4073260000000001, dtype('float64'))),\n",
+       "             ('Opsim_moonphase', (89.153486000000001, dtype('float64'))),\n",
+       "             ('Opsim_expmjd', (49353.032078999997, dtype('float64'))),\n",
+       "             ('Opsim_altitude', (0.73819100000000004, dtype('float64'))),\n",
+       "             ('Opsim_azimuth', (2.5978759999999999, dtype('float64'))),\n",
+       "             ('exptime', (30.0, dtype('float64'))),\n",
+       "             ('airmass', (1.4859990000000001, dtype('float64')))])"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "direct[0].phoSimMetaData"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/examples/ObservationMetaData_Generator_Example.ipynb
+++ b/examples/ObservationMetaData_Generator_Example.ipynb
@@ -69,7 +69,7 @@
    },
    "outputs": [],
    "source": [
-    "gen = ObservationMetaDataGenerator(database=dbPath, driver='sqlite')"
+    "gen = ObservationMetaDataGenerator(dbPath=dbPath, driver='sqlite')"
    ]
   },
   {
@@ -210,7 +210,7 @@
    },
    "outputs": [],
    "source": [
-    "obsMetaData = ObservationMetaDataGenerator.ObservationMetaDataForPointing(record, \n",
+    "obsMetaData = ObservationMetaDataGenerator.ObservationMetaDataFromPointing(record, \n",
     "                                                                          OpSimColumns=colnames,\n",
     "                                                                        columnMap=ObservationMetaDataGenerator.OpSimColumnMap('finSeeing'))"
    ]
@@ -268,7 +268,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 15,
    "metadata": {
     "collapsed": true
    },
@@ -279,7 +279,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 16,
    "metadata": {
     "collapsed": true
    },
@@ -290,7 +290,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 17,
    "metadata": {
     "collapsed": true
    },
@@ -301,7 +301,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 18,
    "metadata": {
     "collapsed": true
    },
@@ -319,7 +319,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 19,
    "metadata": {
     "collapsed": true
    },
@@ -335,7 +335,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 20,
    "metadata": {
     "collapsed": true
    },
@@ -346,7 +346,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 21,
    "metadata": {
     "collapsed": true
    },
@@ -357,18 +357,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 22,
    "metadata": {
     "collapsed": false
    },
    "outputs": [],
    "source": [
-    "obs_metaData = ObservationMetaDataGenerator.ObservationMetaDataForPointing(results[0], columnMap=columnMap, OpSimColumns=results.dtype.names)"
+    "obs_metaData = ObservationMetaDataGenerator.ObservationMetaDataFromPointing(results[0], columnMap=columnMap, OpSimColumns=results.dtype.names)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 23,
    "metadata": {
     "collapsed": false
    },
@@ -396,7 +396,7 @@
        "             ('airmass', (1.4859990000000001, dtype('float64')))])"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -407,7 +407,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 24,
    "metadata": {
     "collapsed": false
    },
@@ -418,7 +418,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 25,
    "metadata": {
     "collapsed": false
    },
@@ -446,7 +446,7 @@
        "             ('airmass', (1.4859990000000001, dtype('float64')))])"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -461,21 +461,61 @@
     "collapsed": true
    },
    "source": [
-    "Getting ObservationMetaData instances for OpSim records in `numpy.recarray`:"
+    "## Getting ObservationMetaData instances for OpSim records in `numpy.recarray`:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 26,
    "metadata": {
     "collapsed": true
    },
    "outputs": [],
    "source": [
-    "obs_metaDataList = list(ObservationMetaDataGenerator.ObservationMetaDataForPointing(result, \n",
+    "obs_metaDataList = list(ObservationMetaDataGenerator.ObservationMetaDataFromPointing(result, \n",
     "                                                                               columnMap=columnMap,\n",
     "                                                                               OpSimColumns=results.dtype.names)\n",
     "                        for result in results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "or directly "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "obs_metaDataListDirect = ObservationMetaDataGenerator.ObservationMetaDataFromPointingArray(results)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "obs_metaDataList == obs_metaDataList"
    ]
   }
  ],

--- a/examples/ObservationMetaData_Generator_Example.ipynb
+++ b/examples/ObservationMetaData_Generator_Example.ipynb
@@ -268,7 +268,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
    "metadata": {
     "collapsed": true
    },
@@ -279,7 +279,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 18,
    "metadata": {
     "collapsed": true
    },
@@ -290,7 +290,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 19,
    "metadata": {
     "collapsed": true
    },
@@ -301,7 +301,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 20,
    "metadata": {
     "collapsed": true
    },
@@ -319,7 +319,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 21,
    "metadata": {
     "collapsed": true
    },
@@ -335,7 +335,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 22,
    "metadata": {
     "collapsed": true
    },
@@ -346,7 +346,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "metadata": {
     "collapsed": true
    },
@@ -357,7 +357,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "metadata": {
     "collapsed": false
    },
@@ -456,13 +456,27 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "Getting ObservationMetaData instances for OpSim records in `numpy.recarray`:"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {
     "collapsed": true
    },
    "outputs": [],
-   "source": []
+   "source": [
+    "obs_metaDataList = list(ObservationMetaDataGenerator.ObservationMetaDataForPointing(result, \n",
+    "                                                                               columnMap=columnMap,\n",
+    "                                                                               OpSimColumns=results.dtype.names)\n",
+    "                        for result in results)"
+   ]
   }
  ],
  "metadata": {

--- a/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
+++ b/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
@@ -394,14 +394,14 @@ class ObservationMetaDataGenerator(object):
             the Summary table in the OpSim database. The minimal list of keys
             required for catsim to work is 'fiveSigmaDepth',
             'filtSkyBrightness', and at least one of ('finSeeing', 'FWHMeff').
-            More keys defined in colunMap may be necessary for PhoSim to work.
+            More keys defined in columnMap may be necessary for PhoSim to work.
         columnMap : A mapping of columns with names exepected by phosim for
             OpSim columns. This can be obtained from
             ObservationMetaDataGenerator.OpSimColumnMap()
         OpSimColumns : tuple of strings, optional, defaults to None
             The columns corresponding to the OpSim records. If None, attempts
             to obtain these from the OpSimRecord as OpSimRecord.dtype.names
-        boundType : {'circle', 'box'}, optiional, defaults to 'circle'
+        boundType : {'circle', 'box'}, optional, defaults to 'circle'
             Shape of the observation
         boundLength : scalar float, optional, defaults to 1.75
             'characteristic size' of observation field, in units of degrees.

--- a/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
+++ b/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
@@ -10,8 +10,18 @@ __all__ = ["ObservationMetaDataGenerator"]
 
 class ObservationMetaDataGenerator(object):
     """
-    This is a class that allows the user to query an opsim output database
-    for ObservationMetaData instantiations that fit certain criteria.
+    A class that allows the user to generate instantiations of
+    `lsst.sims.utils.ObservationMetaData` corresponding to OpSim pointings.
+    The functionality includes:
+    - getOpSimRecords : obtain OpSim records matching user specified ranges
+        on each column in the OpSim output database. The records are in the
+        form of a `numpy.recarray`
+    - ObservationMetaDataForPointing : convert an OpSim record for a single
+        OpSim Pointing to an instance of ObservationMetaData usable by catsim
+        and PhoSim Instance Catalogs.
+    - getObservationMetaData : Obtain a list of ObservationMetaData instances
+        corresponding to OpSim pointings matching user specified ranges on each
+        column of the OpSim output database
 
     The major method is ObservationMetaDataGenerator.getObservationMetaData()
     which accepts bounds on columns of the opsim summary table and returns

--- a/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
+++ b/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
@@ -16,7 +16,7 @@ class ObservationMetaDataGenerator(object):
     - getOpSimRecords : obtain OpSim records matching the intersection of user
         specified ranges on each column in the OpSim output database. The
         records are in the form of a `numpy.recarray`
-    - ObservationMetaDataForPointing : convert an OpSim record for a single
+    - ObservationMetaDataFromPointing : convert an OpSim record for a single
         OpSim Pointing to an instance of ObservationMetaData usable by catsim
         and PhoSim Instance Catalogs.
     - getObservationMetaData : Obtain a list of ObservationMetaData instances
@@ -380,7 +380,7 @@ class ObservationMetaDataGenerator(object):
         return obs_output
 
     @staticmethod
-    def ObservationMetaDataForPointing(OpSimPointingRecord, columnMap,
+    def ObservationMetaDataFromPointing(OpSimPointingRecord, columnMap,
                                        OpSimColumns=None,
                                        boundLength=1.75, boundType='circle'):
         """
@@ -523,7 +523,7 @@ class ObservationMetaDataGenerator(object):
 
         OpSimColumns = OpSimPointingRecords.dtype.names
         # convert the results into ObservationMetaData instantiations
-        out = list(self.ObservationMetaDataForPointing(OpSimPointingRecord,
+        out = list(self.ObservationMetaDataFromPointing(OpSimPointingRecord,
                                                        columnMap=self.columnMapping,
                                                        OpSimColumns=OpSimColumns,
                                                        boundLength=boundLength,

--- a/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
+++ b/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
@@ -5,7 +5,7 @@ import lsst.utils
 from lsst.sims.catalogs.generation.db import DBObject
 from lsst.sims.utils import ObservationMetaData
 
-__all__ = ["ObservationMetaDataGenerator"]
+__all__ = ["ObservationMetaDataGenerator", "ObservationMetaDataForPointing"]
 
 class ObservationMetaDataGenerator(object):
     """
@@ -44,7 +44,7 @@ class ObservationMetaDataGenerator(object):
         """
         if database is None:
             dbPath = os.path.join(lsst.utils.getPackageDir('sims_data'),'OpSimData/')
-            self.database =  os.path.join(dbPath, 'opsimblitz1_1133_sqlite.db')
+            self.database = os.path.join(dbPath, 'opsimblitz1_1133_sqlite.db')
             self.driver = 'sqlite'
             self.host = None
             self.port = None
@@ -91,27 +91,38 @@ class ObservationMetaDataGenerator(object):
         #(and possibly phoSimCatalogExamples.py) will need to be updated to
         #reflect what PhoSim actually expects now.
         #
-        self.columnMapping = [('obsHistID', 'obsHistID', 'Opsim_obshistid' ,numpy.int64, None),
-                              ('expDate', 'expDate', 'SIM_SEED', int, None),
-                              ('fieldRA', 'fieldRA', 'pointingRA', float, numpy.radians),
-                              ('fieldDec', 'fieldDec', 'pointingDec', float, numpy.radians),
-                              ('moonRA', 'moonRA', 'Opsim_moonra', float, numpy.radians),
-                              ('moonDec', 'moonDec', 'Opsim_moondec', float, numpy.radians),
-                              ('rotSkyPos', 'rotSkyPos', 'Opsim_rotskypos', float, numpy.radians),
-                              ('telescopeFilter', 'filter', 'Opsim_filter', (str,1), self._put_quotations),
-                              ('rawSeeing', 'rawSeeing', 'Opsim_rawseeing', float, None),
-                              ('seeing', self._seeing_column, None, float, None),
-                              ('sunAlt', 'sunAlt', 'Opsim_sunalt', float, numpy.radians),
-                              ('moonAlt', 'moonAlt', 'Opsim_moonalt', float, numpy.radians),
-                              ('dist2Moon', 'dist2Moon', 'Opsim_dist2moon', float, numpy.radians),
-                              ('moonPhase', 'moonPhase', 'Opsim_moonphase', float, None),
-                              ('expMJD', 'expMJD', 'Opsim_expmjd', float, None),
-                              ('altitude', 'altitude', 'Opsim_altitude', float, numpy.radians),
-                              ('azimuth', 'azimuth', 'Opsim_azimuth', float, numpy.radians),
-                              ('visitExpTime', 'visitExpTime', 'exptime', float, None),
-                              ('airmass', 'airmass', 'airmass', float, None),
-                              ('m5', 'fiveSigmaDepth', None, float, None),
-                              ('skyBrightness', 'filtSkyBrightness', None, float, None)]
+
+        @staticmethod
+        def OpSimColumnMap():
+            """
+            Return a list of tuples.  Each tuple corresponds to a column in the
+            opsim database's summary table.
+            """
+            v = [('obsHistID', 'obsHistID', 'Opsim_obshistid', numpy.int64, None),
+                 ('expDate', 'expDate', 'SIM_SEED', int, None),
+                 ('fieldRA', 'fieldRA', 'pointingRA', float, numpy.radians),
+                 ('fieldDec', 'fieldDec', 'pointingDec', float, numpy.radians),
+                 ('moonRA', 'moonRA', 'Opsim_moonra', float, numpy.radians),
+                 ('moonDec', 'moonDec', 'Opsim_moondec', float, numpy.radians),
+                 ('rotSkyPos', 'rotSkyPos', 'Opsim_rotskypos', float, numpy.radians),
+                 ('telescopeFilter', 'filter', 'Opsim_filter', (str,1), self._put_quotations),
+                 ('rawSeeing', 'rawSeeing', 'Opsim_rawseeing', float, None),
+                 ('seeing', self._seeing_column, None, float, None),
+                 ('sunAlt', 'sunAlt', 'Opsim_sunalt', float, numpy.radians),
+                 ('moonAlt', 'moonAlt', 'Opsim_moonalt', float, numpy.radians),
+                 ('dist2Moon', 'dist2Moon', 'Opsim_dist2moon', float, numpy.radians),
+                 ('moonPhase', 'moonPhase', 'Opsim_moonphase', float, None),
+                 ('expMJD', 'expMJD', 'Opsim_expmjd', float, None),
+                 ('altitude', 'altitude', 'Opsim_altitude', float, numpy.radians),
+                 ('azimuth', 'azimuth', 'Opsim_azimuth', float, numpy.radians),
+                 ('visitExpTime', 'visitExpTime', 'exptime', float, None),
+                 ('airmass', 'airmass', 'airmass', float, None),
+                 ('m5', 'fiveSigmaDepth', None, float, None),
+                 ('skyBrightness', 'filtSkyBrightness', None, float, None)]
+            return v
+
+
+        self.columnMapping = self.OpSimColumnMap()
 
         #Set up self.dtype containg the dtype of the recarray we expect back from the SQL query.
         #Also setup baseQuery which is just the SELECT clause of the SQL query
@@ -250,4 +261,3 @@ class ObservationMetaDataGenerator(object):
 
 
         return obs_output
-

--- a/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
+++ b/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
@@ -5,8 +5,7 @@ import lsst.utils
 from lsst.sims.catalogs.generation.db import DBObject
 from lsst.sims.utils import ObservationMetaData
 
-__all__ = ["ObservationMetaDataGenerator",
-           "ObservationMetaDataForPointing"]
+__all__ = ["ObservationMetaDataGenerator"]
 
 
 class ObservationMetaDataGenerator(object):
@@ -94,35 +93,8 @@ class ObservationMetaDataGenerator(object):
         # reflect what PhoSim actually expects now.
         #
 
-        @staticmethod
-        def OpSimColumnMap():
-            """
-            Return a list of tuples.  Each tuple corresponds to a column in the
-            opsim database's summary table.
-            """
-            v = [('obsHistID', 'obsHistID', 'Opsim_obshistid', numpy.int64, None),
-                 ('expDate', 'expDate', 'SIM_SEED', int, None),
-                 ('fieldRA', 'fieldRA', 'pointingRA', float, numpy.radians),
-                 ('fieldDec', 'fieldDec', 'pointingDec', float, numpy.radians),
-                 ('moonRA', 'moonRA', 'Opsim_moonra', float, numpy.radians),
-                 ('moonDec', 'moonDec', 'Opsim_moondec', float, numpy.radians),
-                 ('rotSkyPos', 'rotSkyPos', 'Opsim_rotskypos', float, numpy.radians),
-                 ('telescopeFilter', 'filter', 'Opsim_filter', (str, 1), self._put_quotations),
-                 ('rawSeeing', 'rawSeeing', 'Opsim_rawseeing', float, None),
-                 ('seeing', self._seeing_column, None, float, None),
-                 ('sunAlt', 'sunAlt', 'Opsim_sunalt', float, numpy.radians),
-                 ('moonAlt', 'moonAlt', 'Opsim_moonalt', float, numpy.radians),
-                 ('dist2Moon', 'dist2Moon', 'Opsim_dist2moon', float, numpy.radians),
-                 ('moonPhase', 'moonPhase', 'Opsim_moonphase', float, None),
-                 ('expMJD', 'expMJD', 'Opsim_expmjd', float, None),
-                 ('altitude', 'altitude', 'Opsim_altitude', float, numpy.radians),
-                 ('azimuth', 'azimuth', 'Opsim_azimuth', float, numpy.radians),
-                 ('visitExpTime', 'visitExpTime', 'exptime', float, None),
-                 ('airmass', 'airmass', 'airmass', float, None),
-                 ('m5', 'fiveSigmaDepth', None, float, None),
-                 ('skyBrightness', 'filtSkyBrightness', None, float, None)]
-            return v
-
+        # Just use the static method to assign this attribute
+        # to the mapping of names of phoSim to OpSim columns
         self.columnMapping = self.OpSimColumnMap()
 
         #Set up self.dtype containg the dtype of the recarray we expect back from the SQL query.
@@ -142,6 +114,35 @@ class ObservationMetaDataGenerator(object):
                 self.baseQuery += ' ' + column[1]
 
         self.dtype = numpy.dtype(dtypeList)
+
+    @staticmethod
+    def OpSimColumnMap():
+        """
+        Return a list of tuples.  Each tuple corresponds to a column in the
+        opsim database's summary table.
+        """
+        v = [('obsHistID', 'obsHistID', 'Opsim_obshistid', numpy.int64, None),
+             ('expDate', 'expDate', 'SIM_SEED', int, None),
+             ('fieldRA', 'fieldRA', 'pointingRA', float, numpy.radians),
+             ('fieldDec', 'fieldDec', 'pointingDec', float, numpy.radians),
+             ('moonRA', 'moonRA', 'Opsim_moonra', float, numpy.radians),
+             ('moonDec', 'moonDec', 'Opsim_moondec', float, numpy.radians),
+             ('rotSkyPos', 'rotSkyPos', 'Opsim_rotskypos', float, numpy.radians),
+             ('telescopeFilter', 'filter', 'Opsim_filter', (str, 1), self._put_quotations),
+             ('rawSeeing', 'rawSeeing', 'Opsim_rawseeing', float, None),
+             ('seeing', self._seeing_column, None, float, None),
+             ('sunAlt', 'sunAlt', 'Opsim_sunalt', float, numpy.radians),
+             ('moonAlt', 'moonAlt', 'Opsim_moonalt', float, numpy.radians),
+             ('dist2Moon', 'dist2Moon', 'Opsim_dist2moon', float, numpy.radians),
+             ('moonPhase', 'moonPhase', 'Opsim_moonphase', float, None),
+             ('expMJD', 'expMJD', 'Opsim_expmjd', float, None),
+             ('altitude', 'altitude', 'Opsim_altitude', float, numpy.radians),
+             ('azimuth', 'azimuth', 'Opsim_azimuth', float, numpy.radians),
+             ('visitExpTime', 'visitExpTime', 'exptime', float, None),
+             ('airmass', 'airmass', 'airmass', float, None),
+             ('m5', 'fiveSigmaDepth', None, float, None),
+             ('skyBrightness', 'filtSkyBrightness', None, float, None)]
+        return v
 
     def getOpSimRecords(self, obsHistID=None, expDate=None, fieldRA=None,
                         fieldDec=None, moonRA=None, moonDec=None,
@@ -301,7 +302,7 @@ class ObservationMetaDataGenerator(object):
 
         query = self.baseQuery + ' FROM SUMMARY'
 
-        nConstraints = 0 # the number of constraints in this query
+        nConstraints = 0  # the number of constraints in this query
 
         for column in self.columnMapping:
             value = eval(column[0])
@@ -311,8 +312,8 @@ class ObservationMetaDataGenerator(object):
                 else:
                     query += ' WHERE '
 
-                if isinstance(value,tuple):
-                    if len(value)>2:
+                if isinstance(value, tuple):
+                    if len(value) > 2:
                         raise RuntimeError('Cannot pass a tuple longer than 2 elements '+
                                            'to getObservationMetaData: %s is len %d'
                                            % (column[0], len(value)))
@@ -385,7 +386,7 @@ class ObservationMetaDataGenerator(object):
         """
         pointing = OpSimPointingRecord
         # Decide what is the name of the column in the OpSim database
-        # corresponding to the Seeing. For older OpSim outputs, this is 
+        # corresponding to the Seeing. For older OpSim outputs, this is
         # 'finSeeing'. For later OpSim outputs this is 'FWHMeff'
         if 'FWHMeff' in pointing:
             _seeingColumn = 'FWHMeff'
@@ -399,12 +400,103 @@ class ObservationMetaDataGenerator(object):
         # an ordered Dict
         phosimDict = OrderedDict([(col[2], (pointing[col[1]],
                                             pointing[col[1]].dtype))
-                                  for col in self.columnMap
+                                  for col in columnMap
                                   if col[2] is not None])
 
         return ObservationMetaData(m5=pointing['fiveSigmaDepth'],
                                    boundType=boundType,
                                    boundLength=boundLength,
                                    skyBrightness=pointing['filtSkyBrightness'],
-                                   seeing=pointing[_seeing_column],
+                                   seeing=pointing[_seeingColumn],
                                    phoSimMetaData=phosimDict)
+
+
+    def getObservationMetaDataNew(self, obsHistID=None, expDate=None, fieldRA=None, fieldDec=None,
+                               moonRA=None, moonDec=None, rotSkyPos=None, telescopeFilter=None,
+                               rawSeeing=None, seeing=None, sunAlt=None, moonAlt=None, dist2Moon=None,
+                               moonPhase=None, expMJD=None, altitude=None, azimuth=None,
+                               visitExpTime=None, airmass=None, skyBrightness=None,
+                               m5=None, boundType='circle', boundLength=0.1, limit=None):
+
+        """
+        This method will query the OpSim database summary table according to user-specified
+        constraints and return a list of of ObservationMetaData instantiations consistent
+        with those constraints.
+
+        @param [in] limit is an integer denoting the maximum number of ObservationMetaData to
+        be returned
+
+        @param [in] boundType is the boundType of the ObservationMetaData to be returned
+        (see documentation in sims_catalogs_generation/../db/spatialBounds.py for more
+        details)
+
+        @param [in] boundLength is the boundLength of the ObservationMetaData to be
+        returned (in degrees; see documentation in
+        sims_catalogs_generation/../db/spatialBounds.py for more details)
+
+        All other input parameters are constraints to be placed on the SQL query of the
+        opsim output db.  These contraints can either be tuples of the form (min, max)
+        or an exact value the user wants returned.
+
+        Parameters that can be constrained are:
+
+        @param [in] fieldRA in degrees
+        @param [in] fieldDec in degrees
+        @param [in] altitude in degrees
+        @param [in] azimuth in degrees
+
+        @param [in] moonRA in degrees
+        @param [in] moonDec in degrees
+        @param [in] moonAlt in degrees
+        @param [in] moonPhase (a value from 1 to 100 indicating how much of the moon is illuminated)
+        @param [in] dist2Moon the distance between the telescope pointing and the moon in degrees
+
+        @param [in] sunAlt in degrees
+
+        @param [in[ rotSkyPos (the angle of the sky with respect to the camera coordinate system) in degrees
+        @param [in] telescopeFilter a string that is one of u,g,r,i,z,y
+
+        @param [in] airmass
+        @param [in] rawSeeing (this is an idealized seeing at zenith at 500nm in arcseconds)
+        @param [in] seeing (this is the OpSim column 'FWHMeff' or 'finSeeing' [deprecated] in arcseconds)
+
+        @param [in] visitExpTime the exposure time in seconds
+        @param [in] obsHistID the integer used by OpSim to label pointings
+        @param [in] expDate is the date of the exposure (units????)
+        @param [in] expMJD is the MJD of the exposure
+        @param [in] m5 is the five sigma depth of the observation
+        @param [in] skyBrightness
+        """
+
+        OpSimPointingRecords = self.getOpSimRecords(obsHistID=obsHistID,
+                                                    expDate=expDate,
+                                                    fieldRA=fieldRA,
+                                                    fieldDec=fieldDec,
+                                                    moonRA=moonRA,
+                                                    moonDec=moonDec,
+                                                    rotSkyPos=rotSkyPos,
+                                                    telescopeFilter=telescopeFilter,
+                                                    rawSeeing=rawSeeing,
+                                                    seeing=seeing,
+                                                    sunAlt=sunAlt,
+                                                    moonAlt=moonAlt,
+                                                    dist2Moon=dist2Moon,
+                                                    moonPhase=moonPhase,
+                                                    expMJD=expMJD,
+                                                    altitude=altitude,
+                                                    azimuth=azimuth,
+                                                    visitExpTime=visitExpTime,
+                                                    airmass=airmass,
+                                                    skyBrightness=skyBrightness,
+                                                    m5=m5, boundType=boundType,
+                                                    boundLength=boundLength,
+                                                    limit=limit)
+
+        # convert the results into ObservationMetaData instantiations
+        out = list(self.ObservationMetaDataForPointing(OpSimPointingRecord,
+                                                       columnMap=self.columnMap,
+                                                       boundLength=boundLength,
+                                                       boundType=boundType)
+                   for OpSimPointingRecord in OpSimPointingRecords)
+
+        return out

--- a/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
+++ b/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
@@ -201,9 +201,9 @@ class ObservationMetaDataGenerator(object):
         @param [in] skyBrightness
         """
 
-        query = self.baseQuery+ ' FROM SUMMARY'
+        query = self.baseQuery + ' FROM SUMMARY'
 
-        nConstraints = 0 #the number of constraints in this query
+        nConstraints = 0 # the number of constraints in this query
 
         for column in self.columnMapping:
             value = eval(column[0])

--- a/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
+++ b/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
@@ -21,28 +21,13 @@ class ObservationMetaDataGenerator(object):
         and PhoSim Instance Catalogs.
     - getObservationMetaData : Obtain a list of ObservationMetaData instances
         corresponding to OpSim pointings matching the intersection of user
-        specified ranges on each column in the OpSim output database. 
+        specified ranges on each column in the OpSim output database.
 
     The major method is ObservationMetaDataGenerator.getObservationMetaData()
     which accepts bounds on columns of the opsim summary table and returns
     a list of ObservationMetaData instantiations that fall within those
     bounds.
     """
-
-    def _put_quotations(self, val):
-        """
-        This formats the user's input of telescopeFilter; in must be enclosed
-        in single quotation marks.  This method adds them if necessary.
-
-        @param [in] val is a string (denoting a Telescope Filter)
-
-        @param [out] a string containing 'val' (i.e. the input value
-        enclosed in single quotation marks, if they are not already there)
-        """
-        if val[0] == '\'':
-            return val
-        else:
-            return "'%s'" % val
 
     def __init__(self, driver=None, host=None, port=None, database=None):
         """

--- a/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
+++ b/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
@@ -150,37 +150,58 @@ class ObservationMetaDataGenerator(object):
                         skyBrightness=None, m5=None, boundType='circle',
                         boundLength=0.1, limit=None):
         """
-        This method will query the OpSim database summary table according to
-        constraints specified in the input ranges and return a generator to all
-        records from the OpSim database that match those constraints. If limit
+        This method will query the summary table in the `self.opsimdb` database
+        according to constraints specified in the input ranges and return a
+        `numpy.recarray` containing the records that match those constraints. If limit
         is used, the first N records will be returned in the list.
 
         Parameters
         ----------
-        obsHistID :
-        expDate :
-        fieldRA :
-        fieldDec :
-        moonRa :
-        moonDec :
-        rotSkyPos :
-        telescopeFilter :
-        rawSeeing :
-        seeing :
-        sunAlt :
-        moonAlt :
-        dist2Moon :
-        moonPhase :
-        expMJD :
-        altitude :
-        azimuth :
-        visitExpTime :
-        airmass :
-        skyBrightness :
-        m5 :
-        boundType :
-        boundLength :
-        limit :
+        obsHistID, expDate, fieldRA, fieldDec, moonRa, moonDec, rotSkyPos,
+        telescopeFilter, rawSeeing, seeing, sunAlt, moonAlt, dist2Moon, moonPhase, expMJD, 
+        altitude, azimuth, visitExpTime, airmass, skyBrightness, m5 : 
+        boundType : `sims.utils.ObservationMetaData.boundType`, optional, defaults to 'circle'
+            {'circle', 'box'} denoting the shape of the pointing. Further
+            documentation `sims.catalogs.generation.db.spatialBounds.py``
+        boundLength : float, optional, defaults to 0.1
+            sets `sims.utils.ObservationMetaData.boundLenght`
+        limit : integer, optional, defaults to None
+            if not None, denotes max number of records returned by the query
+
+
+
+        All other input parameters are constraints to be placed on the SQL query of the
+        opsim output db.  These contraints can either be tuples of the form (min, max)
+        or an exact value the user wants returned.
+
+        Parameters that can be constrained are:
+
+        @param [in] fieldRA in degrees
+        @param [in] fieldDec in degrees
+        @param [in] altitude in degrees
+        @param [in] azimuth in degrees
+
+        @param [in] moonRA in degrees
+        @param [in] moonDec in degrees
+        @param [in] moonAlt in degrees
+        @param [in] moonPhase (a value from 1 to 100 indicating how much of the moon is illuminated)
+        @param [in] dist2Moon the distance between the telescope pointing and the moon in degrees
+
+        @param [in] sunAlt in degrees
+
+        @param [in[ rotSkyPos (the angle of the sky with respect to the camera coordinate system) in degrees
+        @param [in] telescopeFilter a string that is one of u,g,r,i,z,y
+
+        @param [in] airmass
+        @param [in] rawSeeing (this is an idealized seeing at zenith at 500nm in arcseconds)
+        @param [in] seeing (this is the OpSim column 'FWHMeff' or 'finSeeing' [deprecated] in arcseconds)
+
+        @param [in] visitExpTime the exposure time in seconds
+        @param [in] obsHistID the integer used by OpSim to label pointings
+        @param [in] expDate is the date of the exposure (units????)
+        @param [in] expMJD is the MJD of the exposure
+        @param [in] m5 is the five sigma depth of the observation
+        @param [in] skyBrightness
 
         Returns
         -------
@@ -188,7 +209,7 @@ class ObservationMetaDataGenerator(object):
         res.dtype.names
 
         .. notes:: The `limit` argument should only be used if a small example
-        is required.
+        is required. The angle ranges in the argument should be specified in degrees.
         """
         query = self.baseQuery + ' FROM SUMMARY'
 
@@ -202,7 +223,7 @@ class ObservationMetaDataGenerator(object):
                 else:
                     query += ' WHERE '
 
-                if isinstance(value,tuple):
+                if isinstance(value, tuple):
                     if len(value)>2:
                         raise RuntimeError('Cannot pass a tuple longer than 2 elements '+
                                            'to getObservationMetaData: %s is len %d'

--- a/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
+++ b/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
@@ -5,7 +5,9 @@ import lsst.utils
 from lsst.sims.catalogs.generation.db import DBObject
 from lsst.sims.utils import ObservationMetaData
 
-__all__ = ["ObservationMetaDataGenerator", "ObservationMetaDataForPointing"]
+__all__ = ["ObservationMetaDataGenerator",
+           "ObservationMetaDataForPointings"]
+
 
 class ObservationMetaDataGenerator(object):
     """
@@ -28,7 +30,7 @@ class ObservationMetaDataGenerator(object):
         @param [out] a string containing 'val' (i.e. the input value
         enclosed in single quotation marks, if they are not already there)
         """
-        if val[0]=='\'':
+        if val[0] == '\'':
             return val
         else:
             return "'%s'" % val
@@ -43,7 +45,7 @@ class ObservationMetaDataGenerator(object):
                     stored in sims_data/OpSimData/
         """
         if database is None:
-            dbPath = os.path.join(lsst.utils.getPackageDir('sims_data'),'OpSimData/')
+            dbPath = os.path.join(lsst.utils.getPackageDir('sims_data'), 'OpSimData/')
             self.database = os.path.join(dbPath, 'opsimblitz1_1133_sqlite.db')
             self.driver = 'sqlite'
             self.host = None
@@ -68,28 +70,28 @@ class ObservationMetaDataGenerator(object):
         else:
             self._seeing_column = 'finSeeing'
 
-        #27 January 2015
-        #self.columnMapping is an list of tuples.  Each tuple corresponds to a column in the opsim
-        #database's summary table.
+        # 27 January 2015
+        # self.columnMapping is an list of tuples.  Each tuple corresponds to a column in the opsim
+        # database's summary table.
 
-        #The 0th element of the tuple is how users will
-        #refer to the OpSim summary table columns (ie. how they are called in getObservationMetaDAta).
+        # The 0th element of the tuple is how users will
+        # refer to the OpSim summary table columns (ie. how they are called in getObservationMetaDAta).
         #
-        #The 1st element of the tuple is how the column is named in the OpSim db.
+        # The 1st element of the tuple is how the column is named in the OpSim db.
         #
-        #The 2nd element of the tuple is how PhoSim refers to the quantity (as of OpSim3_61DBObject.py)
-        #(this is None if PhoSim does not expect the quantity)
+        # The 2nd element of the tuple is how PhoSim refers to the quantity (as of OpSim3_61DBObject.py)
+        # (this is None if PhoSim does not expect the quantity)
         #
-        #The 3rd element of the tuple is the datatype of the column
+        # The 3rd element of the tuple is the datatype of the column
         #
-        #The 4th element of the tuple is any coordinate transformation required to go from the user interface
-        #to the OpSim database (i.e. OpSim stores all angles in radians; we would like users to be
-        #able to specify angles in degrees)
+        # The 4th element of the tuple is any coordinate transformation required to go from the user interface
+        # to the OpSim database (i.e. OpSim stores all angles in radians; we would like users to be
+        # able to specify angles in degrees)
         #
-        #Note that this conforms to an older
-        #PhoSim API.  At some time in the future, both this and OpSim3_61DBObject.py
-        #(and possibly phoSimCatalogExamples.py) will need to be updated to
-        #reflect what PhoSim actually expects now.
+        # Note that this conforms to an older
+        # PhoSim API.  At some time in the future, both this and OpSim3_61DBObject.py
+        # (and possibly phoSimCatalogExamples.py) will need to be updated to
+        # reflect what PhoSim actually expects now.
         #
 
         @staticmethod
@@ -105,7 +107,7 @@ class ObservationMetaDataGenerator(object):
                  ('moonRA', 'moonRA', 'Opsim_moonra', float, numpy.radians),
                  ('moonDec', 'moonDec', 'Opsim_moondec', float, numpy.radians),
                  ('rotSkyPos', 'rotSkyPos', 'Opsim_rotskypos', float, numpy.radians),
-                 ('telescopeFilter', 'filter', 'Opsim_filter', (str,1), self._put_quotations),
+                 ('telescopeFilter', 'filter', 'Opsim_filter', (str, 1), self._put_quotations),
                  ('rawSeeing', 'rawSeeing', 'Opsim_rawseeing', float, None),
                  ('seeing', self._seeing_column, None, float, None),
                  ('sunAlt', 'sunAlt', 'Opsim_sunalt', float, numpy.radians),
@@ -120,7 +122,6 @@ class ObservationMetaDataGenerator(object):
                  ('m5', 'fiveSigmaDepth', None, float, None),
                  ('skyBrightness', 'filtSkyBrightness', None, float, None)]
             return v
-
 
         self.columnMapping = self.OpSimColumnMap()
 
@@ -250,7 +251,7 @@ class ObservationMetaDataGenerator(object):
         results = self.opsimdb.execute_arbitrary(query, dtype=self.dtype)
 
 
-        #convert the results into ObservationMetaData instantiations
+        # convert the results into ObservationMetaData instantiations
         obs_output = [ObservationMetaData(m5=pointing['fiveSigmaDepth'], boundType=boundType, boundLength=boundLength,
                                           skyBrightness=pointing['filtSkyBrightness'],
                                           seeing=pointing[self._seeing_column],
@@ -258,6 +259,5 @@ class ObservationMetaDataGenerator(object):
                                                                     (pointing[column[1]], pointing[column[1]].dtype))
                                                                     for column in self.active_columns if column[2] is not None]))
                                           for pointing in results]
-
 
         return obs_output

--- a/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
+++ b/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
@@ -13,15 +13,15 @@ class ObservationMetaDataGenerator(object):
     A class that allows the user to generate instantiations of
     `lsst.sims.utils.ObservationMetaData` corresponding to OpSim pointings.
     The functionality includes:
-    - getOpSimRecords : obtain OpSim records matching user specified ranges
-        on each column in the OpSim output database. The records are in the
-        form of a `numpy.recarray`
+    - getOpSimRecords : obtain OpSim records matching the intersection of user
+        specified ranges on each column in the OpSim output database. The
+        records are in the form of a `numpy.recarray`
     - ObservationMetaDataForPointing : convert an OpSim record for a single
         OpSim Pointing to an instance of ObservationMetaData usable by catsim
         and PhoSim Instance Catalogs.
     - getObservationMetaData : Obtain a list of ObservationMetaData instances
-        corresponding to OpSim pointings matching user specified ranges on each
-        column of the OpSim output database
+        corresponding to OpSim pointings matching the intersection of user
+        specified ranges on each column in the OpSim output database. 
 
     The major method is ObservationMetaDataGenerator.getObservationMetaData()
     which accepts bounds on columns of the opsim summary table and returns
@@ -128,8 +128,10 @@ class ObservationMetaDataGenerator(object):
     @staticmethod
     def OpSimColumnMap(seeing_column):
         """
-        Return a list of tuples.  Each tuple corresponds to a column in the
-        opsim database's summary table.
+        Return a list of tuples.  Each tuple has the following elements :
+        (phosimName, OpSimName, unknown, dtype, callable)
+
+        Needs some work:
         """
         v = [('obsHistID', 'obsHistID', 'Opsim_obshistid', numpy.int64, None),
              ('expDate', 'expDate', 'SIM_SEED', int, None),

--- a/tests/testObservationMetaDataGenerator.py
+++ b/tests/testObservationMetaDataGenerator.py
@@ -373,6 +373,7 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
         catName = 'testPhoSimFromObsMetaDataGenerator.txt'
         if os.path.exists(dbName):
             os.unlink(dbName)
+        _ = makePhoSimTestDB(filename=dbName)
         bulgeDB = testGalaxyBulge(driver='sqlite', database=dbName)
         gen = ObservationMetaDataGenerator()
         results = gen.getObservationMetaData(fieldRA=numpy.degrees(1.370916),

--- a/tests/testObservationMetaDataGenerator.py
+++ b/tests/testObservationMetaDataGenerator.py
@@ -101,6 +101,7 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
         ('m5',(22.815249, 23.0)),
         ('skyBrightness',(19.017605, 19.5))]
 
+
         # test querying on a single column
         for line in bounds:
             tag = line[0]
@@ -109,25 +110,31 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
             # corresponds to this bound
             for ii in range(len(gen.columnMapping)):
                 if gen.columnMapping[ii][0] == tag:
+                    opsimKey = gen.columnMapping[ii][1]
                     break
 
             if tag != 'telescopeFilter' and tag != 'visitExpTime':
                 args = {}
                 args[tag] = line[1]
                 results = gen.getObservationMetaData(**args)
+                OpSimRecords = gen.getOpSimRecords(**args)
 
                 if tag == 'skyBrightness':
                     ct = 0
                     for obs_metadata in results:
                         self.assertLess(obs_metadata.skyBrightness, line[1][1])
+                        self.assertLess(OpSimRecords[opsimKey].max(), line[1][1])
                         self.assertGreater(obs_metadata.skyBrightness, line[1][0])
+                        self.assertGreater(OpSimRecords[opsimKey].min(), line[1][0])
                         ct += 1
                     self.assertGreater(ct, 0)
                 elif tag == 'm5':
                     ct = 0
                     for obs_metadata in results:
                         self.assertLess(obs_metadata.m5[obs_metadata.bandpass], line[1][1])
+                        self.assertLess(OpSimRecords[opsimKey].max(), line[1][1])
                         self.assertGreater(obs_metadata.m5[obs_metadata.bandpass], line[1][0])
+                        self.assertGreater(OpSimRecords[opsimKey].min(), line[1][0])
                         ct += 1
                     self.assertGreater(ct, 0)
 

--- a/tests/testObservationMetaDataGenerator.py
+++ b/tests/testObservationMetaDataGenerator.py
@@ -9,6 +9,7 @@ from lsst.sims.catalogs.generation.db import CatalogDBObject
 from lsst.sims.catUtils.baseCatalogModels import GalaxyBulgeObj, GalaxyDiskObj, GalaxyAgnObj, StarObj
 from lsst.sims.catUtils.exampleCatalogDefinitions import PhoSimCatalogSersic2D
 from lsst.sims.catalogs.generation.utils import makePhoSimTestDB
+from lsst.utils import getPackageDir
 
 #28 January 2015
 #SearchReversion and testGalaxyBulge are duplicated from testPhoSimCatalogs.py
@@ -64,12 +65,17 @@ class testGalaxyBulge(SearchReversion, GalaxyBulgeObj):
 
 class ObservationMetaDataGeneratorTest(unittest.TestCase):
 
+    def setUp(self):
+        dbPath = os.path.join(getPackageDir('sims_data'),
+                             'OpSimData/opsimblitz1_1133_sqlite.db')
+        self.gen = ObservationMetaDataGenerator(dbPath=dbPath,
+                                                driver='sqlite')
 
     def testExceptions(self):
         """
         Make sure that RuntimeErrors get raised when they should
         """
-        gen = ObservationMetaDataGenerator()
+        gen = self.gen
         self.assertRaises(RuntimeError, gen.getObservationMetaData)
         self.assertRaises(RuntimeError, gen.getObservationMetaData,fieldRA=(1.0, 2.0, 3.0))
 
@@ -82,7 +88,7 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
 
         Test when querying on both a single and two columns.
         """
-        gen = ObservationMetaDataGenerator()
+        gen = self.gen
 
         # An list containing the bounds of our queries.
         # The order of the tuples must correspond to the order of
@@ -211,7 +217,7 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
         Test that ObservationMetaData returned by a query demanding an exact value do,
         in fact, adhere to that requirement.
         """
-        gen = ObservationMetaDataGenerator()
+        gen = self.gen
 
         bounds = [
         ('obsHistID',5973),
@@ -275,7 +281,7 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
         Test that, when we specify a limit on the number of ObservationMetaData we want returned,
         that limit is respected
         """
-        gen = ObservationMetaDataGenerator()
+        gen = self.gen
         results = gen.getObservationMetaData(fieldRA=(numpy.degrees(1.370916), numpy.degrees(1.5348635)),
                                              limit=20)
         self.assertEqual(len(results), 20)
@@ -284,7 +290,7 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
         """
         Test that queries on the filter work.
         """
-        gen = ObservationMetaDataGenerator()
+        gen = self.gen
         results = gen.getObservationMetaData(fieldRA=numpy.degrees(1.370916), telescopeFilter='i')
         ct = 0
         for obs_metadata in results:
@@ -301,7 +307,7 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
         sky) are correctly passed through to the resulting ObservationMetaData
         """
 
-        gen = ObservationMetaDataGenerator()
+        gen = self.gen
 
         # Test a cirlce with a specified radius
         results = gen.getObservationMetaData(fieldRA=numpy.degrees(1.370916),
@@ -375,7 +381,7 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
             os.unlink(dbName)
         _ = makePhoSimTestDB(filename=dbName)
         bulgeDB = testGalaxyBulge(driver='sqlite', database=dbName)
-        gen = ObservationMetaDataGenerator()
+        gen = self.gen
         results = gen.getObservationMetaData(fieldRA=numpy.degrees(1.370916),
                                              telescopeFilter='i')
         testCat = PhoSimCatalogSersic2D(bulgeDB, obs_metadata=results[0])

--- a/tests/testObservationMetaDataGenerator.py
+++ b/tests/testObservationMetaDataGenerator.py
@@ -84,12 +84,12 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
         """
         gen = ObservationMetaDataGenerator()
 
-        #An list containing the bounds of our queries.
-        #The order of the tuples must correspond to the order of
-        #self.columnMapping in ObservationMetaDataGenerator.
-        #This was generated with a separate script which printed
-        #the median and maximum values of all of the quantities
-        #in our test opsim database
+        # An list containing the bounds of our queries.
+        # The order of the tuples must correspond to the order of
+        # self.columnMapping in ObservationMetaDataGenerator.
+        # This was generated with a separate script which printed
+        # the median and maximum values of all of the quantities
+        # in our test opsim database
         bounds = [
         ('obsHistID',(5973, 7000)),
         ('fieldRA',(numpy.degrees(1.370916), numpy.degrees(1.40))),
@@ -101,7 +101,7 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
         ('m5',(22.815249, 23.0)),
         ('skyBrightness',(19.017605, 19.5))]
 
-        #test querying on a single column
+        # test querying on a single column
         for line in bounds:
             tag = line[0]
 
@@ -145,11 +145,11 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
                         self.assertLess(obs_metadata.phoSimMetaData[name][0], xmax)
                         self.assertGreater(obs_metadata.phoSimMetaData[name][0], xmin)
 
-                    #make sure that we did not accidentally choose values such that
-                    #no ObservationMetaData were ever returned
+                    # make sure that we did not accidentally choose values such that
+                    # no ObservationMetaData were ever returned
                     self.assertGreater(ct, 0)
 
-        #test querying on two columns at once
+        # test querying on two columns at once
         ct = 0
         for ix in range(len(bounds)):
             tag1 = bounds[ix][0]
@@ -195,10 +195,9 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
                                     self.assertGreater(obs_metadata.phoSimMetaData[name2][0], ymin)
                                     self.assertLess(obs_metadata.phoSimMetaData[name2][0], ymax)
 
-        #Make sure that we didn't choose values such that no ObservationMetaData were
-        #ever returned
+        # Make sure that we didn't choose values such that no ObservationMetaData were
+        # ever returned
         self.assertGreater(ct, 0)
-
 
     def testQueryExactValues(self):
         """
@@ -249,7 +248,7 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
                         self.assertAlmostEqual(value, obs_metadata.phoSimMetaData[name][0],10)
                         ct += 1
 
-                    #Make sure that we did not choose a value which returns zero ObservationMetaData
+                    # Make sure that we did not choose a value which returns zero ObservationMetaData
                     self.assertGreater(ct, 0)
                 elif tag == 'm5':
                     ct = 0
@@ -264,8 +263,6 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
                         ct += 1
                     self.assertGreater(ct, 0)
 
-
-
     def testQueryLimit(self):
         """
         Test that, when we specify a limit on the number of ObservationMetaData we want returned,
@@ -274,8 +271,7 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
         gen = ObservationMetaDataGenerator()
         results = gen.getObservationMetaData(fieldRA=(numpy.degrees(1.370916), numpy.degrees(1.5348635)),
                                              limit=20)
-        self.assertEqual(len(results),20)
-
+        self.assertEqual(len(results), 20)
 
     def testQueryOnFilter(self):
         """
@@ -285,27 +281,28 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
         results = gen.getObservationMetaData(fieldRA=numpy.degrees(1.370916), telescopeFilter='i')
         ct = 0
         for obs_metadata in results:
-            self.assertAlmostEqual(obs_metadata.phoSimMetaData['pointingRA'][0],1.370916)
-            self.assertEqual(obs_metadata.phoSimMetaData['Opsim_filter'][0],'i')
+            self.assertAlmostEqual(obs_metadata.phoSimMetaData['pointingRA'][0], 1.370916)
+            self.assertEqual(obs_metadata.phoSimMetaData['Opsim_filter'][0], 'i')
             ct += 1
 
-        #Make sure that more than zero ObservationMetaData were returned
+        # Make sure that more than zero ObservationMetaData were returned
         self.assertGreater(ct, 0)
-
 
     def testObsMetaDataBounds(self):
         """
-        Make sure that the bound specifications (i.e. a circle or a box on the sky) are correctly
-        passed through to the resulting ObservationMetaData
+        Make sure that the bound specifications (i.e. a circle or a box on the
+        sky) are correctly passed through to the resulting ObservationMetaData
         """
 
         gen = ObservationMetaDataGenerator()
 
-        #Test a cirlce with a specified radius
-        results = gen.getObservationMetaData(fieldRA=numpy.degrees(1.370916), telescopeFilter='i', boundLength=0.9)
+        # Test a cirlce with a specified radius
+        results = gen.getObservationMetaData(fieldRA=numpy.degrees(1.370916),
+                                             telescopeFilter='i',
+                                             boundLength=0.9)
         ct = 0
         for obs_metadata in results:
-            self.assertTrue(isinstance(obs_metadata.bounds,CircleBounds))
+            self.assertTrue(isinstance(obs_metadata.bounds, CircleBounds))
 
             # include some wiggle room, in case ObservationMetaData needs to
             # adjust the boundLength to accommodate the transformation between
@@ -313,17 +310,21 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
             self.assertGreaterEqual(obs_metadata.bounds.radiusdeg, 0.9)
             self.assertLess(obs_metadata.bounds.radiusdeg, 0.95)
 
-            self.assertAlmostEqual(obs_metadata.bounds.RA, obs_metadata.phoSimMetaData['pointingRA'][0], 5)
-            self.assertAlmostEqual(obs_metadata.bounds.DEC, obs_metadata.phoSimMetaData['pointingDec'][0], 5)
+            self.assertAlmostEqual(obs_metadata.bounds.RA,
+                                   obs_metadata.phoSimMetaData['pointingRA'][0], 5)
+            self.assertAlmostEqual(obs_metadata.bounds.DEC,
+                                   obs_metadata.phoSimMetaData['pointingDec'][0], 5)
             ct += 1
 
-        #Make sure that some ObservationMetaData were tested
+        # Make sure that some ObservationMetaData were tested
         self.assertGreater(ct, 0)
 
         boundLengthList = [1.2, (1.2, 0.6)]
         for boundLength in boundLengthList:
-            results = gen.getObservationMetaData(fieldRA=numpy.degrees(1.370916), telescopeFilter='i',
-                                                 boundType='box', boundLength=boundLength)
+            results = gen.getObservationMetaData(fieldRA=numpy.degrees(1.370916),
+                                                 telescopeFilter='i',
+                                                 boundType='box',
+                                                 boundLength=boundLength)
 
             if hasattr(boundLength, '__len__'):
                 dra = boundLength[0]
@@ -336,7 +337,7 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
             for obs_metadata in results:
                 RAdeg = numpy.degrees(obs_metadata.phoSimMetaData['pointingRA'][0])
                 DECdeg = numpy.degrees(obs_metadata.phoSimMetaData['pointingDec'][0])
-                self.assertTrue(isinstance(obs_metadata.bounds,BoxBounds))
+                self.assertTrue(isinstance(obs_metadata.bounds, BoxBounds))
 
                 self.assertAlmostEqual(obs_metadata.bounds.RAminDeg, RAdeg-dra, 10)
 
@@ -351,34 +352,34 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
 
                 ct += 1
 
-            #Make sure that some ObservationMetaData were tested
+            # Make sure that some ObservationMetaData were tested
             self.assertGreater(ct, 0)
-
 
     def testCreationOfPhoSimCatalog(self):
         """
-        Make sure that we can create PhoSim input catalogs using the returned ObservationMetaData.
-        This test will just make sure that all of the expected header entries are there.
+        Make sure that we can create PhoSim input catalogs using the returned
+        ObservationMetaData. This test will just make sure that all of the
+        expected header entries are there.
         """
 
         dbName = 'obsMetaDataGeneratorTest.db'
         catName = 'testPhoSimFromObsMetaDataGenerator.txt'
         if os.path.exists(dbName):
             os.unlink(dbName)
-        junk_obs_metadata = makePhoSimTestDB(filename=dbName)
         bulgeDB = testGalaxyBulge(driver='sqlite', database=dbName)
         gen = ObservationMetaDataGenerator()
-        results = gen.getObservationMetaData(fieldRA=numpy.degrees(1.370916),telescopeFilter='i')
+        results = gen.getObservationMetaData(fieldRA=numpy.degrees(1.370916),
+                                             telescopeFilter='i')
         testCat = PhoSimCatalogSersic2D(bulgeDB, obs_metadata=results[0])
         testCat.write_catalog(catName)
 
-        filterTranslation=['u','g','r','i','z','y']
+        filterTranslation=['u', 'g', 'r', 'i', 'z', 'y']
 
         with open(catName) as inputFile:
             lines = inputFile.readlines()
             ix = 0
             for control in gen.columnMapping:
-                if control[0] != 'm5' and control[0]!='skyBrightness' and control[0]!='seeing':
+                if control[0] != 'm5' and control[0] != 'skyBrightness' and control[0] != 'seeing':
                     words = lines[ix].split()
                     self.assertEqual(control[2].replace('pointing', 'Unrefracted_'), words[0])
 
@@ -390,7 +391,7 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
 
                         self.assertAlmostEqual(value, results[0].phoSimMetaData[control[2]][0], 5)
                     else:
-                        self.assertEqual(filterTranslation[int(words[1])],results[0].phoSimMetaData[control[2]][0])
+                        self.assertEqual(filterTranslation[int(words[1])], results[0].phoSimMetaData[control[2]][0])
 
                     ix += 1
 
@@ -401,7 +402,6 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
             os.unlink(dbName)
 
 
-
 def suite():
     utilsTests.init()
     suites = []
@@ -409,7 +409,8 @@ def suite():
 
     return unittest.TestSuite(suites)
 
-def run(shouldExit = False):
+
+def run(shouldExit=False):
     utilsTests.run(suite(), shouldExit)
 if __name__ == "__main__":
     run(True)


### PR DESCRIPTION
Copied from original pull request:

Split functionality on ObservationMetaDataGenerator into :

- getOpSimRecords : obtain OpSim records matching the intersection of user specified ranges on each column in the OpSim output database. The records are in the form of a numpy.recarray

- ObservationMetaDataForPointing : convert an OpSim record for a single OpSim Pointing to an instance of ObservationMetaData usable by catsim and PhoSim Instance Catalogs.

- getObservationMetaData : Obtain a list of ObservationMetaData instances corresponding to OpSim pointings matching the intersection of user specified ranges on each column in the OpSim output database. This should be identitcal to the old getObservationMetaData

The old method getObservationMetaData is still there as getObservationMetaDataOld only for testing purposes.

A few tests were added to check that the OpSimRecords queried had the same properties as the ObservationMetaDataInstances.

Example Notebook added for demonstration of usage where the OpSim records have been selected by the user.
