### PR TITLE
Feature/sim 1471/pho sim meta data

### DIFF
--- a/python/lsst/sims/catUtils/exampleCatalogDefinitions/phoSimCatalogExamples.py
+++ b/python/lsst/sims/catUtils/exampleCatalogDefinitions/phoSimCatalogExamples.py
@@ -3,9 +3,8 @@ import numpy as np
 from lsst.sims.utils import SpecMap, defaultSpecMap
 from lsst.sims.catalogs.measures.instance import InstanceCatalog, compound
 from lsst.sims.utils import arcsecFromRadians, _observedFromICRS, altAzPaFromRaDec
-from lsst.sims.catUtils.mixins import AstrometryStars, AstrometryGalaxies, \
-                                      AstrometrySSM, EBVmixin, PhoSimAstrometryStars, \
-                                      PhoSimAstrometryGalaxies, PhoSimAstrometrySSM
+from lsst.sims.catUtils.mixins import (EBVmixin, PhoSimAstrometryStars,
+                                       PhoSimAstrometryGalaxies, PhoSimAstrometrySSM)
 
 __all__ = ["write_phoSim_header", "PhosimInputBase",
            "PhoSimCatalogPoint", "PhoSimCatalogZPoint",
@@ -13,7 +12,7 @@ __all__ = ["write_phoSim_header", "PhosimInputBase",
 
 
 PhoSimSpecMap = SpecMap(fileDict=defaultSpecMap.fileDict,
-                        dirDict={'(^lte)':'starSED/phoSimMLT'})
+                        dirDict={'(^lte)': 'starSED/phoSimMLT'})
 
 
 def write_phoSim_header(obs, file_handle):
@@ -35,7 +34,7 @@ def write_phoSim_header(obs, file_handle):
         airmass = 1.0/np.cos(0.5*np.pi-np.radians(alt))
         file_handle.write('airmass %.9g\n' % airmass)
         file_handle.write('Opsim_filter %d\n' %
-                      {'u':0, 'g':1, 'r':2, 'i':3, 'z':4, 'y':5}[obs.bandpass])
+                          {'u': 0, 'g': 1, 'r': 2, 'i': 3, 'z': 4, 'y': 5}[obs.bandpass])
 
         file_handle.write('Opsim_rotskypos %.9g\n' % obs.rotSkyPos)
     except:
@@ -44,7 +43,6 @@ def write_phoSim_header(obs, file_handle):
         print "lacks one of the required parameters"
         print "(pointingRA, pointingDec, mjd, bandpass, rotSkyPos)"
         raise
-
 
     already_written = ('Unrefracted_RA', 'Unrefracted_Dec',
                        'Opsim_expmjd', 'Opsim_altitude',
@@ -59,10 +57,9 @@ def write_phoSim_header(obs, file_handle):
         file_handle.write('%s %.9g\n' % (kk, obs._phoSimMetadata[kk]))
 
 
-
 class PhosimInputBase(InstanceCatalog):
 
-    filtMap = dict([(c, i) for i,c in enumerate('ugrizy')])
+    filtMap = dict([(c, i) for i, c in enumerate('ugrizy')])
 
     specFileMap = PhoSimSpecMap
 
@@ -70,21 +67,17 @@ class PhosimInputBase(InstanceCatalog):
 
     delimiter = " "
 
-
     def get_prefix(self):
         chunkiter = xrange(len(self.column_by_name(self.refIdCol)))
         return np.array(['object' for i in chunkiter], dtype=(str, 6))
-
 
     def get_sedFilepath(self):
         return np.array([self.specFileMap[k] if self.specFileMap.has_key(k) else None
                          for k in self.column_by_name('sedFilename')])
 
-
     def get_spatialmodel(self):
         chunkiter = xrange(len(self._current_chunk))
-        return np.array([self.spatialModel for i in
-               chunkiter], dtype=(str, 8))
+        return np.array([self.spatialModel for i in chunkiter], dtype=(str, 8))
 
     def get_phoSimMagNorm(self):
         """
@@ -121,72 +114,71 @@ class PhoSimCatalogPoint(PhosimInputBase, PhoSimAstrometryStars, EBVmixin):
 
     catalog_type = 'phoSim_catalog_POINT'
 
-    column_outputs = ['prefix', 'uniqueId','raPhoSim','decPhoSim','phoSimMagNorm','sedFilepath',
-                      'redshift','shear1','shear2','kappa','raOffset','decOffset',
-                      'spatialmodel','galacticExtinctionModel','galacticAv','galacticRv',
+    column_outputs = ['prefix', 'uniqueId', 'raPhoSim', 'decPhoSim', 'phoSimMagNorm', 'sedFilepath',
+                      'redshift', 'shear1', 'shear2', 'kappa', 'raOffset', 'decOffset',
+                      'spatialmodel', 'galacticExtinctionModel', 'galacticAv', 'galacticRv',
                       'internalExtinctionModel']
 
-    default_columns = [('redshift', 0., float),('shear1', 0., float), ('shear2', 0., float),
+    default_columns = [('redshift', 0., float), ('shear1', 0., float), ('shear2', 0., float),
                        ('kappa', 0., float), ('raOffset', 0., float), ('decOffset', 0., float),
-                       ('galacticExtinctionModel', 'CCM', (str,3)), ('galacticRv', 3.1, float),
-                       ('internalExtinctionModel', 'none', (str,4))]
+                       ('galacticExtinctionModel', 'CCM', (str, 3)), ('galacticRv', 3.1, float),
+                       ('internalExtinctionModel', 'none', (str, 4))]
 
-    default_formats = {'S':'%s', 'f':'%.9g', 'i':'%i'}
+    default_formats = {'S': '%s', 'f': '%.9g', 'i': '%i'}
 
     spatialModel = "point"
 
-    transformations = {'raPhoSim':np.degrees, 'decPhoSim':np.degrees}
+    transformations = {'raPhoSim': np.degrees, 'decPhoSim': np.degrees}
 
 
 class PhoSimCatalogZPoint(PhosimInputBase, PhoSimAstrometryGalaxies, EBVmixin):
 
     catalog_type = 'phoSim_catalog_ZPOINT'
 
-    column_outputs = ['prefix', 'uniqueId','raPhoSim','decPhoSim','phoSimMagNorm','sedFilepath',
-                      'redshift','shear1','shear2','kappa','raOffset','decOffset',
-                      'spatialmodel','galacticExtinctionModel','galacticAv','galacticRv',
+    column_outputs = ['prefix', 'uniqueId', 'raPhoSim', 'decPhoSim', 'phoSimMagNorm', 'sedFilepath',
+                      'redshift', 'shear1', 'shear2', 'kappa', 'raOffset', 'decOffset',
+                      'spatialmodel', 'galacticExtinctionModel', 'galacticAv', 'galacticRv',
                       'internalExtinctionModel']
 
     default_columns = [('shear1', 0., float), ('shear2', 0., float), ('kappa', 0., float),
-                       ('raOffset', 0., float), ('decOffset', 0., float), ('spatialmodel', 'ZPOINT', (str, 6)),
-                       ('galacticExtinctionModel', 'CCM', (str,3)),
+                       ('raOffset', 0., float), ('decOffset', 0., float),
+                       ('spatialmodel', 'ZPOINT', (str, 6)),
+                       ('galacticExtinctionModel', 'CCM', (str, 3)),
                        ('galacticAv', 0.1, float), ('galacticRv', 3.1, float),
-                       ('internalExtinctionModel', 'none', (str,4))]
+                       ('internalExtinctionModel', 'none', (str, 4))]
 
-    default_formats = {'S':'%s', 'f':'%.9g', 'i':'%i'}
+    default_formats = {'S': '%s', 'f': '%.9g', 'i': '%i'}
 
     spatialModel = "point"
 
-    transformations = {'raPhoSim':np.degrees, 'decPhoSim':np.degrees}
-
+    transformations = {'raPhoSim': np.degrees, 'decPhoSim': np.degrees}
 
 
 class PhoSimCatalogSersic2D(PhoSimCatalogZPoint):
 
     catalog_type = 'phoSim_catalog_SERSIC2D'
 
-    column_outputs = ['prefix', 'uniqueId','raPhoSim','decPhoSim','phoSimMagNorm','sedFilepath',
-                      'redshift','shear1','shear2','kappa','raOffset','decOffset',
-                      'spatialmodel','majorAxis','minorAxis','positionAngle','sindex',
-                      'galacticExtinctionModel','galacticAv','galacticRv',
-                      'internalExtinctionModel','internalAv','internalRv']
+    column_outputs = ['prefix', 'uniqueId', 'raPhoSim', 'decPhoSim', 'phoSimMagNorm', 'sedFilepath',
+                      'redshift', 'shear1', 'shear2', 'kappa', 'raOffset', 'decOffset',
+                      'spatialmodel', 'majorAxis', 'minorAxis', 'positionAngle', 'sindex',
+                      'galacticExtinctionModel', 'galacticAv', 'galacticRv',
+                      'internalExtinctionModel', 'internalAv', 'internalRv']
 
     default_columns = [('shear1', 0., float), ('shear2', 0., float), ('kappa', 0., float),
                        ('raOffset', 0., float), ('decOffset', 0., float),
                        ('galacticAv', 0.1, float), ('galacticRv', 3.1, float),
-                       ('galacticExtinctionModel', 'CCM', (str,3)),
-                       ('internalExtinctionModel', 'CCM', (str,3)), ('internalAv', 0., float),
-                       ('internalRv', 3.1, float) ]
+                       ('galacticExtinctionModel', 'CCM', (str, 3)),
+                       ('internalExtinctionModel', 'CCM', (str, 3)), ('internalAv', 0., float),
+                       ('internalRv', 3.1, float)]
 
-    default_formats = {'S':'%s', 'f':'%.9g', 'i':'%i'}
+    default_formats = {'S': '%s', 'f': '%.9g', 'i': '%i'}
 
     spatialModel = "sersic2d"
 
-    transformations = {'raPhoSim':np.degrees, 'decPhoSim':np.degrees, 'positionAngle':np.degrees,
-                       'majorAxis':arcsecFromRadians, 'minorAxis':arcsecFromRadians}
+    transformations = {'raPhoSim': np.degrees, 'decPhoSim': np.degrees, 'positionAngle': np.degrees,
+                       'majorAxis': arcsecFromRadians, 'minorAxis': arcsecFromRadians}
 
-
-    @compound('raPhoSim','decPhoSim')
+    @compound('raPhoSim', 'decPhoSim')
     def get_phoSimCoordinates(self):
         """Getter for RA, Dec coordinates expected by PhoSim.
 
@@ -208,17 +200,17 @@ class PhoSimCatalogSSM(PhosimInputBase, PhoSimAstrometrySSM):
 
     catalog_type = 'phoSim_catalog_SSM'
 
-    column_outputs = ['prefix', 'uniqueId','raPhoSim','decPhoSim','phoSimMagNorm','sedFilepath',
-                      'redshift','shear1','shear2','kappa','raOffset','decOffset',
-                      'spatialmodel','galacticExtinctionModel', 'internalExtinctionModel']
+    column_outputs = ['prefix', 'uniqueId', 'raPhoSim', 'decPhoSim', 'phoSimMagNorm', 'sedFilepath',
+                      'redshift', 'shear1', 'shear2', 'kappa', 'raOffset', 'decOffset',
+                      'spatialmodel', 'galacticExtinctionModel', 'internalExtinctionModel']
 
-    default_columns = [('redshift', 0., float),('shear1', 0., float), ('shear2', 0., float),
+    default_columns = [('redshift', 0., float), ('shear1', 0., float), ('shear2', 0., float),
                        ('kappa', 0., float), ('raOffset', 0., float), ('decOffset', 0., float),
-                       ('galacticExtinctionModel', 'none', (str,3)),
-                       ('internalExtinctionModel', 'none', (str,4))]
+                       ('galacticExtinctionModel', 'none', (str, 3)),
+                       ('internalExtinctionModel', 'none', (str, 4))]
 
-    default_formats = {'S':'%s', 'f':'%.9g', 'i':'%i'}
+    default_formats = {'S': '%s', 'f': '%.9g', 'i': '%i'}
 
     spatialModel = "point"
 
-    transformations = {'raPhoSim':np.degrees, 'decPhoSim':np.degrees}
+    transformations = {'raPhoSim': np.degrees, 'decPhoSim': np.degrees}

--- a/python/lsst/sims/catUtils/exampleCatalogDefinitions/phoSimCatalogExamples.py
+++ b/python/lsst/sims/catUtils/exampleCatalogDefinitions/phoSimCatalogExamples.py
@@ -1,5 +1,5 @@
 """Instance Catalog"""
-import numpy
+import numpy as np
 from lsst.sims.utils import SpecMap, defaultSpecMap
 from lsst.sims.catalogs.measures.instance import InstanceCatalog, compound
 from lsst.sims.utils import arcsecFromRadians, _observedFromICRS, altAzPaFromRaDec
@@ -32,7 +32,7 @@ def write_phoSim_header(obs, file_handle):
         alt, az, pa = altAzPaFromRaDec(obs.pointingRA, obs.pointingDec, obs)
         file_handle.write('Opsim_altitude %.9g\n' % alt)
         file_handle.write('Opsim_azimuth %.9g\n' % az)
-        airmass = 1.0/numpy.cos(0.5*numpy.pi-numpy.radians(alt))
+        airmass = 1.0/np.cos(0.5*np.pi-np.radians(alt))
         file_handle.write('airmass %.9g\n' % airmass)
         file_handle.write('Opsim_filter %d\n' %
                       {'u':0, 'g':1, 'r':2, 'i':3, 'z':4, 'y':5}[obs.bandpass])
@@ -73,17 +73,17 @@ class PhosimInputBase(InstanceCatalog):
 
     def get_prefix(self):
         chunkiter = xrange(len(self.column_by_name(self.refIdCol)))
-        return numpy.array(['object' for i in chunkiter], dtype=(str, 6))
+        return np.array(['object' for i in chunkiter], dtype=(str, 6))
 
 
     def get_sedFilepath(self):
-        return numpy.array([self.specFileMap[k] if self.specFileMap.has_key(k) else None
+        return np.array([self.specFileMap[k] if self.specFileMap.has_key(k) else None
                          for k in self.column_by_name('sedFilename')])
 
 
     def get_spatialmodel(self):
         chunkiter = xrange(len(self._current_chunk))
-        return numpy.array([self.spatialModel for i in
+        return np.array([self.spatialModel for i in
                chunkiter], dtype=(str, 8))
 
     def get_phoSimMagNorm(self):
@@ -135,7 +135,7 @@ class PhoSimCatalogPoint(PhosimInputBase, PhoSimAstrometryStars, EBVmixin):
 
     spatialModel = "point"
 
-    transformations = {'raPhoSim':numpy.degrees, 'decPhoSim':numpy.degrees}
+    transformations = {'raPhoSim':np.degrees, 'decPhoSim':np.degrees}
 
 
 class PhoSimCatalogZPoint(PhosimInputBase, PhoSimAstrometryGalaxies, EBVmixin):
@@ -157,7 +157,7 @@ class PhoSimCatalogZPoint(PhosimInputBase, PhoSimAstrometryGalaxies, EBVmixin):
 
     spatialModel = "point"
 
-    transformations = {'raPhoSim':numpy.degrees, 'decPhoSim':numpy.degrees}
+    transformations = {'raPhoSim':np.degrees, 'decPhoSim':np.degrees}
 
 
 
@@ -182,7 +182,7 @@ class PhoSimCatalogSersic2D(PhoSimCatalogZPoint):
 
     spatialModel = "sersic2d"
 
-    transformations = {'raPhoSim':numpy.degrees, 'decPhoSim':numpy.degrees, 'positionAngle':numpy.degrees,
+    transformations = {'raPhoSim':np.degrees, 'decPhoSim':np.degrees, 'positionAngle':np.degrees,
                        'majorAxis':arcsecFromRadians, 'minorAxis':arcsecFromRadians}
 
 
@@ -221,4 +221,4 @@ class PhoSimCatalogSSM(PhosimInputBase, PhoSimAstrometrySSM):
 
     spatialModel = "point"
 
-    transformations = {'raPhoSim':numpy.degrees, 'decPhoSim':numpy.degrees}
+    transformations = {'raPhoSim':np.degrees, 'decPhoSim':np.degrees}

--- a/python/lsst/sims/catUtils/exampleCatalogDefinitions/phoSimCatalogExamples.py
+++ b/python/lsst/sims/catUtils/exampleCatalogDefinitions/phoSimCatalogExamples.py
@@ -39,6 +39,7 @@ def write_phoSim_header(obs, file_handle):
 
         file_handle.write('Opsim_rotskypos %.9g\n' % obs.rotSkyPos)
     except:
+        print "\n\n"
         print "The ObservationMetaData you tried to write a PhoSim header from"
         print "lacks one of the required parameters"
         print "(pointingRA, pointingDec, mjd, bandpass, rotSkyPos)"

--- a/python/lsst/sims/catUtils/exampleCatalogDefinitions/phoSimCatalogExamples.py
+++ b/python/lsst/sims/catUtils/exampleCatalogDefinitions/phoSimCatalogExamples.py
@@ -26,18 +26,18 @@ def write_phoSim_header(obs, file_handle):
     file_handle points to the catalog being written.
     """
     try:
-        file_handle.write('Unrefracted_RA %f\n' % obs.pointingRA)
-        file_handle.write('Unrefracted_Dec %f\n' % obs.pointingDec)
-        file_handle.write('Opsim_expmjd %f\n' % obs.mjd.TAI)
+        file_handle.write('Unrefracted_RA %.9g\n' % obs.pointingRA)
+        file_handle.write('Unrefracted_Dec %.9g\n' % obs.pointingDec)
+        file_handle.write('Opsim_expmjd %.9g\n' % obs.mjd.TAI)
         alt, az, pa = altAzPaFromRaDec(obs.pointingRA, obs.pointingDec, obs)
-        file_handle.write('Opsim_altitude %f\n' % alt)
-        file_handle.write('Opsim_azimuth %f\n' % az)
+        file_handle.write('Opsim_altitude %.9g\n' % alt)
+        file_handle.write('Opsim_azimuth %.9g\n' % az)
         airmass = 1.0/numpy.cos(numpy.pi-numpy.radians(alt))
-        file_handle.write('airmass %f\n' % airmass)
+        file_handle.write('airmass %.9g\n' % airmass)
         file_handle.write('Opsim_filter %d\n' %
                       {'u':0, 'g':1, 'r':2, 'i':3, 'z':4, 'y':5}[obs.bandpass])
 
-        file_handle.write('Opsim_rotskypos %f\n' % obs.rotSkyPos)
+        file_handle.write('Opsim_rotskypos %.9g\n' % obs.rotSkyPos)
     except:
         print "The ObservationMetaData you tried to write a PhoSim header from"
         print "lacks one of the required parameters"
@@ -55,7 +55,7 @@ def write_phoSim_header(obs, file_handle):
             raise RuntimeError("This ObservationMetaData has conflicting values for "
                                "%s" % kk)
 
-        file_handle.write('%s %f\n' % (kk, obs._phoSimMetadata[kk]))
+        file_handle.write('%s %.9g\n' % (kk, obs._phoSimMetadata[kk]))
 
 
 

--- a/python/lsst/sims/catUtils/exampleCatalogDefinitions/phoSimCatalogExamples.py
+++ b/python/lsst/sims/catUtils/exampleCatalogDefinitions/phoSimCatalogExamples.py
@@ -32,7 +32,7 @@ def write_phoSim_header(obs, file_handle):
         alt, az, pa = altAzPaFromRaDec(obs.pointingRA, obs.pointingDec, obs)
         file_handle.write('Opsim_altitude %.9g\n' % alt)
         file_handle.write('Opsim_azimuth %.9g\n' % az)
-        airmass = 1.0/numpy.cos(numpy.pi-numpy.radians(alt))
+        airmass = 1.0/numpy.cos(0.5*numpy.pi-numpy.radians(alt))
         file_handle.write('airmass %.9g\n' % airmass)
         file_handle.write('Opsim_filter %d\n' %
                       {'u':0, 'g':1, 'r':2, 'i':3, 'z':4, 'y':5}[obs.bandpass])

--- a/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
+++ b/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
@@ -86,6 +86,9 @@ class ObservationMetaDataGenerator(object):
         # to the OpSim database (i.e. OpSim stores all angles in radians; we would like users to be
         # able to specify angles in degrees)
         #
+        # The 5th column is any coordinate transformation required to go from the OpSim database
+        # to the PhoSim header
+        #
         # Note that this conforms to an older
         # PhoSim API.  At some time in the future, both this and OpSim3_61DBObject.py
         # (and possibly phoSimCatalogExamples.py) will need to be updated to
@@ -122,27 +125,27 @@ class ObservationMetaDataGenerator(object):
 
         Needs some work:
         """
-        v = [('obsHistID', 'obsHistID', 'Opsim_obshistid', numpy.int64, None),
-             ('expDate', 'expDate', 'SIM_SEED', int, None),
-             ('fieldRA', 'fieldRA', 'Unrefracted_RA', float, numpy.radians),
-             ('fieldDec', 'fieldDec', 'Unrefracted_Dec', float, numpy.radians),
-             ('moonRA', 'moonRA', 'Opsim_moonra', float, numpy.radians),
-             ('moonDec', 'moonDec', 'Opsim_moondec', float, numpy.radians),
-             ('rotSkyPos', 'rotSkyPos', 'Opsim_rotskypos', float, numpy.radians),
-             ('telescopeFilter', 'filter', 'Opsim_filter', (str, 1), lambda x: '\'{}\''.format(x)),
-             ('rawSeeing', 'rawSeeing', 'Opsim_rawseeing', float, None),
-             ('seeing', seeing_column, None, float, None),
-             ('sunAlt', 'sunAlt', 'Opsim_sunalt', float, numpy.radians),
-             ('moonAlt', 'moonAlt', 'Opsim_moonalt', float, numpy.radians),
-             ('dist2Moon', 'dist2Moon', 'Opsim_dist2moon', float, numpy.radians),
-             ('moonPhase', 'moonPhase', 'Opsim_moonphase', float, None),
-             ('expMJD', 'expMJD', 'Opsim_expmjd', float, None),
-             ('altitude', 'altitude', 'Opsim_altitude', float, numpy.radians),
-             ('azimuth', 'azimuth', 'Opsim_azimuth', float, numpy.radians),
-             ('visitExpTime', 'visitExpTime', 'exptime', float, None),
-             ('airmass', 'airmass', 'airmass', float, None),
-             ('m5', 'fiveSigmaDepth', None, float, None),
-             ('skyBrightness', 'filtSkyBrightness', None, float, None)]
+        v = [('obsHistID', 'obsHistID', 'Opsim_obshistid', numpy.int64, None, None),
+             ('expDate', 'expDate', 'SIM_SEED', int, None, None),
+             ('fieldRA', 'fieldRA', 'Unrefracted_RA', float, numpy.radians, numpy.degrees),
+             ('fieldDec', 'fieldDec', 'Unrefracted_Dec', float, numpy.radians, numpy.degrees),
+             ('moonRA', 'moonRA', 'Opsim_moonra', float, numpy.radians, numpy.degrees),
+             ('moonDec', 'moonDec', 'Opsim_moondec', float, numpy.radians, numpy.degrees),
+             ('rotSkyPos', 'rotSkyPos', 'Opsim_rotskypos', float, numpy.radians, numpy.degrees),
+             ('telescopeFilter', 'filter', 'Opsim_filter', (str, 1), lambda x: '\'{}\''.format(x), None),
+             ('rawSeeing', 'rawSeeing', 'Opsim_rawseeing', float, None, None),
+             ('seeing', seeing_column, None, float, None, None),
+             ('sunAlt', 'sunAlt', 'Opsim_sunalt', float, numpy.radians, numpy.degrees),
+             ('moonAlt', 'moonAlt', 'Opsim_moonalt', float, numpy.radians, numpy.degrees),
+             ('dist2Moon', 'dist2Moon', 'Opsim_dist2moon', float, numpy.radians, numpy.degrees),
+             ('moonPhase', 'moonPhase', 'Opsim_moonphase', float, None, None),
+             ('expMJD', 'expMJD', 'Opsim_expmjd', float, None, None),
+             ('altitude', 'altitude', 'Opsim_altitude', float, numpy.radians, numpy.degrees),
+             ('azimuth', 'azimuth', 'Opsim_azimuth', float, numpy.radians, numpy.degrees),
+             ('visitExpTime', 'visitExpTime', 'exptime', float, None, None),
+             ('airmass', 'airmass', 'airmass', float, None, None),
+             ('m5', 'fiveSigmaDepth', None, float, None, None),
+             ('skyBrightness', 'filtSkyBrightness', None, float, None, None)]
         return v
 
     def getOpSimRecords(self, obsHistID=None, expDate=None, fieldRA=None,
@@ -301,6 +304,10 @@ class ObservationMetaDataGenerator(object):
                                 'filtSkyBrightness', _seeingColumn,
                                 'rotSkyPos', 'altitude', 'azimuth',
                                 'airmass'))])
+
+        for col in columnMap:
+            if col[2] in phosimDict and col[5] is not None:
+                phosimDict[col[2]] = col[5](phosimDict[col[2]])
 
         obs = ObservationMetaData(pointingRA=numpy.degrees(pointing['fieldRA']),
                                   pointingDec=numpy.degrees(pointing['fieldDec']),

--- a/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
+++ b/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
@@ -328,7 +328,7 @@ class ObservationMetaDataGenerator(object):
 
         return obs
 
-    @staticmethod 
+    @staticmethod
     def ObservationMetaDataFromPointingArray(OpSimPointingRecords,
                                                 OpSimColumns=None,
                                                 boundLength=1.75,
@@ -338,7 +338,7 @@ class ObservationMetaDataGenerator(object):
         corresponding to the records in `numpy.recarray`, where it uses
         the dtypes of the recArray for ObservationMetaData attributes that
         require the dtype.
-    
+
         Parameters
         ----------
         OpSimPointingRecords : `numpy.recarray` of OpSim Records
@@ -352,29 +352,29 @@ class ObservationMetaDataGenerator(object):
             'box', this is the length of the side of the square box. For boundType
             'circle' this is the radius.
         """
-    
+
         if OpSimColumns is None:
             OpSimColumns = OpSimPointingRecords.dtype.names
-    
+
         # Find out what the Seeing Variable is called in these OpSim records
         seeingVar = None
-        matches = 0 
+        matches = 0
         for var in ['finSeeing', 'FWHMeff']:
             if var in OpSimColumns:
                 seeingVar = var
                 matches += 1
         if matches in [0, 2]:
             raise ValueError('finSeeing or FWHMeff not in OpSimColumn\n')
-    
+
         columnMapping = ObservationMetaDataGenerator.OpSimColumnMap(seeingVar)
-    
+
         out = list(ObservationMetaDataGenerator.ObservationMetaDataFromPointing(OpSimPointingRecord,
                                                         columnMap=columnMapping,
                                                         OpSimColumns=OpSimColumns,
                                                         boundLength=boundLength,
                                                         boundType=boundType)
                    for OpSimPointingRecord in OpSimPointingRecords)
-    
+
         return out
 
     def getObservationMetaData(self, obsHistID=None, expDate=None, fieldRA=None, fieldDec=None,

--- a/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
+++ b/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 from lsst.sims.catalogs.generation.db import DBObject
 from lsst.sims.utils import ObservationMetaData
 
@@ -73,23 +73,23 @@ class ObservationMetaDataGenerator(object):
         # a dict keyed on the user interface (i.e. args to getObservationMetaData)
         # names of OpSim data columns.  Returns a tuple that is the
         # (name of data in OpSim, transformation to go from user interface to OpSim units, dtyp in OpSim)
-        self._user_interface_to_opsim = {'obsHistID': ('obsHistID', None, numpy.int64),
+        self._user_interface_to_opsim = {'obsHistID': ('obsHistID', None, np.int64),
                                          'expDate': ('expDate', None, int),
-                                         'fieldRA': ('fieldRA', numpy.radians, float),
-                                         'fieldDec': ('fieldDec', numpy.radians, float),
-                                         'moonRA': ('moonRA', numpy.radians, float),
-                                         'moonDec': ('moonDec', numpy.radians, float),
-                                         'rotSkyPos': ('rotSkyPos', numpy.radians, float),
+                                         'fieldRA': ('fieldRA', np.radians, float),
+                                         'fieldDec': ('fieldDec', np.radians, float),
+                                         'moonRA': ('moonRA', np.radians, float),
+                                         'moonDec': ('moonDec', np.radians, float),
+                                         'rotSkyPos': ('rotSkyPos', np.radians, float),
                                          'telescopeFilter':
                                              ('filter', lambda x: '\'{}\''.format(x), (str, 1)),
                                          'rawSeeing': ('rawSeeing', None, float),
-                                         'sunAlt': ('sunAlt', numpy.radians, float),
-                                         'moonAlt': ('moonAlt', numpy.radians, float),
-                                         'dist2Moon': ('dist2Moon', numpy.radians, float),
+                                         'sunAlt': ('sunAlt', np.radians, float),
+                                         'moonAlt': ('moonAlt', np.radians, float),
+                                         'dist2Moon': ('dist2Moon', np.radians, float),
                                          'moonPhase': ('moonPhase', None, float),
                                          'expMJD': ('expMJD', None, float),
-                                         'altitude': ('altitude', numpy.radians, float),
-                                         'azimuth': ('azimuth', numpy.radians, float),
+                                         'altitude': ('altitude', np.radians, float),
+                                         'azimuth': ('azimuth', np.radians, float),
                                          'visitExpTime': ('visitExpTime', None, float),
                                          'airmass': ('airmass', None, float),
                                          'm5': ('fiveSigmaDepth', None, float),
@@ -99,13 +99,13 @@ class ObservationMetaDataGenerator(object):
         # is (PhoSim name of column, transformation needed to go from OpSim to PhoSim)
         self._opsim_to_phosim = {'obsHistID': ('Opsim_obshistid', None),
                                  'expDate': ('SIM_SEED', None),
-                                 'moonRA': ('Opsim_moonra', numpy.degrees),
-                                 'moonDec': ('Opsim_moondec', numpy.degrees),
+                                 'moonRA': ('Opsim_moonra', np.degrees),
+                                 'moonDec': ('Opsim_moondec', np.degrees),
                                  'filter': ('Opsim_filter', None),
                                  'rawSeeing': ('Opsim_rawseeing', None),
-                                 'sunAlt': ('Opsim_sunalt', numpy.degrees),
-                                 'moonAlt': ('Opsim_moonalt', numpy.degrees),
-                                 'dist2Moon': ('Opsim_dist2moon', numpy.degrees),
+                                 'sunAlt': ('Opsim_sunalt', np.degrees),
+                                 'moonAlt': ('Opsim_moonalt', np.degrees),
+                                 'dist2Moon': ('Opsim_dist2moon', np.degrees),
                                  'moonPhase': ('Opsim_moonphase', None),
                                  'visitExpTime': ('exptime', None)}
 
@@ -139,7 +139,7 @@ class ObservationMetaDataGenerator(object):
                     self.baseQuery += ','
                 self.baseQuery += ' ' + rec[0]
 
-        self.dtype = numpy.dtype(dtypeList)
+        self.dtype = np.dtype(dtypeList)
 
     def getOpSimRecords(self, obsHistID=None, expDate=None, fieldRA=None,
                         fieldDec=None, moonRA=None, moonDec=None,
@@ -295,10 +295,10 @@ class ObservationMetaDataGenerator(object):
             if transform[0] in phosimDict and transform[1] is not None:
                 phosimDict[transform[0]] = transform[1](phosimDict[transform[0]])
 
-        obs = ObservationMetaData(pointingRA=numpy.degrees(pointing['fieldRA']),
-                                  pointingDec=numpy.degrees(pointing['fieldDec']),
+        obs = ObservationMetaData(pointingRA=np.degrees(pointing['fieldRA']),
+                                  pointingDec=np.degrees(pointing['fieldDec']),
                                   mjd=pointing['expMJD'],
-                                  rotSkyPos=numpy.degrees(pointing['rotSkyPos']),
+                                  rotSkyPos=np.degrees(pointing['rotSkyPos']),
                                   bandpassName=pointing['filter'],
                                   boundType=boundType,
                                   boundLength=boundLength)

--- a/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
+++ b/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
@@ -300,7 +300,6 @@ class ObservationMetaDataGenerator(object):
         obs = ObservationMetaData(pointingRA=np.degrees(pointing['fieldRA']),
                                   pointingDec=np.degrees(pointing['fieldDec']),
                                   mjd=pointing['expMJD'],
-                                  rotSkyPos=np.degrees(pointing['rotSkyPos']),
                                   bandpassName=pointing['filter'],
                                   boundType=boundType,
                                   boundLength=boundLength)
@@ -311,6 +310,8 @@ class ObservationMetaDataGenerator(object):
             obs.skyBrightness = pointing['filtSkyBrightness']
         if self._seeing_column in pointing_column_names:
             obs.seeing = pointing[self._seeing_column]
+        if 'rotSkyPos' in pointing_column_names:
+            obs.rotSkyPos = np.degrees(pointing['rotSkyPos'])
 
         obs.phoSimMetaData = phosimDict
 

--- a/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
+++ b/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
@@ -344,14 +344,6 @@ class ObservationMetaDataGenerator(object):
         if OpSimColumns is None:
             OpSimColumns = OpSimPointingRecords.dtype.names
 
-        # Find out what the Seeing Variable is called in these OpSim records
-        matches = 0
-        for var in ['finSeeing', 'FWHMeff']:
-            if var in OpSimColumns:
-                matches += 1
-        if matches in [0, 2]:
-            raise ValueError('finSeeing or FWHMeff not in OpSimColumn\n')
-
         out = list(self.ObservationMetaDataFromPointing(OpSimPointingRecord,
                                                         OpSimColumns=OpSimColumns,
                                                         boundLength=boundLength,

--- a/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
+++ b/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
@@ -280,6 +280,8 @@ class ObservationMetaDataGenerator(object):
 
         self._set_seeing_column(OpSimColumns)
 
+        # check to make sure the OpSim pointings being supplied contain
+        # the minimum required information
         for required_column in ('fieldRA', 'fieldDec', 'expMJD', 'filter'):
             if required_column not in OpSimColumns:
                 raise RuntimeError("ObservationMetaDataGenerator requires that the database of "

--- a/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
+++ b/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
@@ -199,6 +199,9 @@ class ObservationMetaDataGenerator(object):
             transform = self._user_interface_to_opsim[column]
             value = eval(column)
             if value is not None:
+                if column not in self.active_columns:
+                    raise RuntimeError("You have asked ObservationMetaDataGenerator to SELECT pointings on"
+                                       "%s; that column does not exist in your OpSim database" % column)
                 if nConstraints > 0:
                     query += ' AND'
                 else:

--- a/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
+++ b/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
@@ -72,7 +72,7 @@ class ObservationMetaDataGenerator(object):
 
         # a dict keyed on the user interface (i.e. args to getObservationMetaData)
         # names of OpSim data columns.  Returns a tuple that is the
-        # (name of data in OpSim, transformation to go from user interface to OpSim units, dtyp in OpSim)
+        # (name of data in OpSim, transformation to go from user interface to OpSim units, dtype in OpSim)
         self._user_interface_to_opsim = {'obsHistID': ('obsHistID', None, np.int64),
                                          'expDate': ('expDate', None, int),
                                          'fieldRA': ('fieldRA', np.radians, float),

--- a/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
+++ b/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
@@ -448,13 +448,3 @@ class ObservationMetaDataGenerator(object):
                                                            boundType=boundType,
                                                            boundLength=boundLength)
         return output
-
-        # OpSimColumns = OpSimPointingRecords.dtype.names
-        # convert the results into ObservationMetaData instantiations
-        # out = list(self.ObservationMetaDataFromPointing(OpSimPointingRecord,
-        #                                                 columnMap=self.columnMapping,
-        #                                                 OpSimColumns=OpSimColumns,
-        #                                                 boundLength=boundLength,
-        #                                                 boundType=boundType)
-        #          for OpSimPointingRecord in OpSimPointingRecords)
-        # return out

--- a/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
+++ b/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
@@ -72,7 +72,8 @@ class ObservationMetaDataGenerator(object):
 
         # a dict keyed on the user interface (i.e. args to getObservationMetaData)
         # names of OpSim data columns.  Returns a tuple that is the
-        # (name of data in OpSim, transformation to go from user interface to OpSim units, dtype in OpSim)
+        # (name of data column in OpSim, transformation to go from user interface to OpSim units,
+        # dtype in OpSim)
         self._user_interface_to_opsim = {'obsHistID': ('obsHistID', None, np.int64),
                                          'expDate': ('expDate', None, int),
                                          'fieldRA': ('fieldRA', np.radians, float),

--- a/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
+++ b/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
@@ -1,6 +1,4 @@
-import os
 import numpy
-import lsst.utils
 from lsst.sims.catalogs.generation.db import DBObject
 from lsst.sims.utils import ObservationMetaData
 
@@ -31,6 +29,10 @@ class ObservationMetaDataGenerator(object):
     def _set_seeing_column(self, summary_columns):
         """
         summary_columns is a list of columns in the OpSim database schema
+
+        This method sets the member variable self._seeing_column to a string
+        denoting the name of the seeing column in the OpSimDatabase.  It also
+        sets self._user_interface_to_opsim['seeing'] to the correct value.
         """
 
         if 'FWHMeff' in summary_columns:
@@ -68,7 +70,6 @@ class ObservationMetaDataGenerator(object):
         self.database = database
         self._seeing_column = 'FWHMeff'
 
-
         # a dict keyed on the user interface (i.e. args to getObservationMetaData)
         # names of OpSim data columns.  Returns a tuple that is the
         # (name of data in OpSim, transformation to go from user interface to OpSim units, dtyp in OpSim)
@@ -79,7 +80,8 @@ class ObservationMetaDataGenerator(object):
                                          'moonRA': ('moonRA', numpy.radians, float),
                                          'moonDec': ('moonDec', numpy.radians, float),
                                          'rotSkyPos': ('rotSkyPos', numpy.radians, float),
-                                         'telescopeFilter': ('filter', lambda x: '\'{}\''.format(x), (str, 1)),
+                                         'telescopeFilter':
+                                             ('filter', lambda x: '\'{}\''.format(x), (str, 1)),
                                          'rawSeeing': ('rawSeeing', None, float),
                                          'sunAlt': ('sunAlt', numpy.radians, float),
                                          'moonAlt': ('moonAlt', numpy.radians, float),
@@ -91,8 +93,7 @@ class ObservationMetaDataGenerator(object):
                                          'visitExpTime': ('visitExpTime', None, float),
                                          'airmass': ('airmass', None, float),
                                          'm5': ('fiveSigmaDepth', None, float),
-                                         'skyBrightness': ('filtSkyBrightness', None, float)
-                                        }
+                                         'skyBrightness': ('filtSkyBrightness', None, float)}
 
         # a dict keyed on the OpSim names for data columns that returns a tuple that
         # is (PhoSim name of column, transformation needed to go from OpSim to PhoSim)
@@ -106,9 +107,7 @@ class ObservationMetaDataGenerator(object):
                                  'moonAlt': ('Opsim_moonalt', numpy.degrees),
                                  'dist2Moon': ('Opsim_dist2moon', numpy.degrees),
                                  'moonPhase': ('Opsim_moonphase', None),
-                                 'visitExpTime': ('exptime', None)
-                                }
-
+                                 'visitExpTime': ('exptime', None)}
 
         if self.database is None:
             return
@@ -123,12 +122,11 @@ class ObservationMetaDataGenerator(object):
         summary_columns = self.opsimdb.get_column_names('Summary')
         self._set_seeing_column(summary_columns)
 
-
-        #Set up self.dtype containg the dtype of the recarray we expect back from the SQL query.
-        #Also setup baseQuery which is just the SELECT clause of the SQL query
+        # Set up self.dtype containg the dtype of the recarray we expect back from the SQL query.
+        # Also setup baseQuery which is just the SELECT clause of the SQL query
         #
-        #self.active_columns will be a list containing the subset of columnMapping columns
-        #that actually exist in this opsim database
+        # self.active_columns will be a list containing the subset of columnMapping columns
+        # that actually exist in this opsim database
         dtypeList = []
         self.baseQuery = 'SELECT'
         self.active_columns = []
@@ -136,7 +134,7 @@ class ObservationMetaDataGenerator(object):
             rec = self._user_interface_to_opsim[column]
             if rec[0] in summary_columns:
                 self.active_columns.append(column)
-                dtypeList.append((rec[0],rec[2]))
+                dtypeList.append((rec[0], rec[2]))
                 if self.baseQuery != 'SELECT':
                     self.baseQuery += ','
                 self.baseQuery += ' ' + rec[0]
@@ -196,7 +194,7 @@ class ObservationMetaDataGenerator(object):
 
         query = self.baseQuery + ' FROM SUMMARY'
 
-        nConstraints = 0 # the number of constraints in this query
+        nConstraints = 0  # the number of constraints in this query
 
         for column in self._user_interface_to_opsim:
             transform = self._user_interface_to_opsim[column]
@@ -208,8 +206,8 @@ class ObservationMetaDataGenerator(object):
                     query += ' WHERE '
 
                 if isinstance(value, tuple):
-                    if len(value)>2:
-                        raise RuntimeError('Cannot pass a tuple longer than 2 elements '+
+                    if len(value) > 2:
+                        raise RuntimeError('Cannot pass a tuple longer than 2 elements ' +
                                            'to getObservationMetaData: %s is len %d'
                                            % (column, len(value)))
 
@@ -244,7 +242,6 @@ class ObservationMetaDataGenerator(object):
 
         results = self.opsimdb.execute_arbitrary(query, dtype=self.dtype)
         return results
-
 
     def ObservationMetaDataFromPointing(self, OpSimPointingRecord, OpSimColumns=None,
                                         boundLength=1.75, boundType='circle'):
@@ -318,9 +315,9 @@ class ObservationMetaDataGenerator(object):
         return obs
 
     def ObservationMetaDataFromPointingArray(self, OpSimPointingRecords,
-                                                OpSimColumns=None,
-                                                boundLength=1.75,
-                                                boundType='circle'):
+                                             OpSimColumns=None,
+                                             boundLength=1.75,
+                                             boundType='circle'):
         """
         Static method to get a list of instances of ObservationMetaData
         corresponding to the records in `numpy.recarray`, where it uses
@@ -345,11 +342,9 @@ class ObservationMetaDataGenerator(object):
             OpSimColumns = OpSimPointingRecords.dtype.names
 
         # Find out what the Seeing Variable is called in these OpSim records
-        seeingVar = None
         matches = 0
         for var in ['finSeeing', 'FWHMeff']:
             if var in OpSimColumns:
-                seeingVar = var
                 matches += 1
         if matches in [0, 2]:
             raise ValueError('finSeeing or FWHMeff not in OpSimColumn\n')

--- a/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
+++ b/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
@@ -125,8 +125,8 @@ class ObservationMetaDataGenerator(object):
         # Set up self.dtype containg the dtype of the recarray we expect back from the SQL query.
         # Also setup baseQuery which is just the SELECT clause of the SQL query
         #
-        # self.active_columns will be a list containing the subset of columnMapping columns
-        # that actually exist in this opsim database
+        # self.active_columns will be a list containing the subset of OpSim database columns
+        # (specified in self._user_interface_to_opsim) that actually exist in this opsim database
         dtypeList = []
         self.baseQuery = 'SELECT'
         self.active_columns = []

--- a/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
+++ b/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
@@ -28,9 +28,12 @@ class ObservationMetaDataGenerator(object):
     bounds.
     """
 
-    def _set_seeing_column(self):
+    def _set_seeing_column(self, summary_columns):
+        """
+        summary_columns is a list of columns in the OpSim database schema
+        """
 
-        if 'FWHMeff' in self._summary_columns:
+        if 'FWHMeff' in summary_columns:
             self._seeing_column = 'FWHMeff'
         else:
             self._seeing_column = 'finSeeing'
@@ -117,8 +120,8 @@ class ObservationMetaDataGenerator(object):
         # Detect whether the OpSim db you are connecting to uses 'finSeeing'
         # as its seeing column (deprecated), or FWHMeff, which is the modern
         # standard
-        self._summary_columns = self.opsimdb.get_column_names('Summary')
-        self._set_seeing_column()
+        summary_columns = self.opsimdb.get_column_names('Summary')
+        self._set_seeing_column(summary_columns)
 
 
         #Set up self.dtype containg the dtype of the recarray we expect back from the SQL query.
@@ -131,7 +134,7 @@ class ObservationMetaDataGenerator(object):
         self.active_columns = []
         for column in self._user_interface_to_opsim:
             rec = self._user_interface_to_opsim[column]
-            if rec[0] in self._summary_columns:
+            if rec[0] in summary_columns:
                 self.active_columns.append(column)
                 dtypeList.append((rec[0],rec[2]))
                 if self.baseQuery != 'SELECT':
@@ -188,8 +191,8 @@ class ObservationMetaDataGenerator(object):
         is required. The angle ranges in the argument should be specified in degrees.
         """
 
-        self._summary_columns = self.opsimdb.get_column_names('Summary')
-        self._set_seeing_column()
+        summary_columns = self.opsimdb.get_column_names('Summary')
+        self._set_seeing_column(summary_columns)
 
         query = self.baseQuery + ' FROM SUMMARY'
 
@@ -276,9 +279,7 @@ class ObservationMetaDataGenerator(object):
         if OpSimColumns is None:
             OpSimColumns = pointing_column_names
 
-        self._summary_columns = OpSimColumns
-
-        self._set_seeing_column()
+        self._set_seeing_column(OpSimColumns)
 
         # convert list of tuples of the form (Name, (value, dtype)) to
         # an ordered Dict

--- a/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
+++ b/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
@@ -280,6 +280,12 @@ class ObservationMetaDataGenerator(object):
 
         self._set_seeing_column(OpSimColumns)
 
+        for required_column in ('fieldRA', 'fieldDec', 'expMJD', 'filter'):
+            if required_column not in OpSimColumns:
+                raise RuntimeError("ObservationMetaDataGenerator requires that the database of "
+                                   "pointings include the coluns:\nfieldRA (in radians)"
+                                   "\nfieldDec (in radians)\nexpMJD\nfilter")
+
         # convert list of tuples of the form (Name, (value, dtype)) to
         # an ordered Dict
         phosimDict = dict([(self._opsim_to_phosim[col][0], pointing[col])

--- a/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
+++ b/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
@@ -26,16 +26,16 @@ class ObservationMetaDataGenerator(object):
     bounds.
     """
 
-    def _set_seeing_column(self, summary_columns):
+    def _set_seeing_column(self, input_summary_columns):
         """
-        summary_columns is a list of columns in the OpSim database schema
+        input_summary_columns is a list of columns in the OpSim database schema
 
         This method sets the member variable self._seeing_column to a string
         denoting the name of the seeing column in the OpSimDatabase.  It also
         sets self._user_interface_to_opsim['seeing'] to the correct value.
         """
 
-        if 'FWHMeff' in summary_columns:
+        if 'FWHMeff' in input_summary_columns:
             self._seeing_column = 'FWHMeff'
         else:
             self._seeing_column = 'finSeeing'
@@ -119,8 +119,8 @@ class ObservationMetaDataGenerator(object):
         # Detect whether the OpSim db you are connecting to uses 'finSeeing'
         # as its seeing column (deprecated), or FWHMeff, which is the modern
         # standard
-        summary_columns = self.opsimdb.get_column_names('Summary')
-        self._set_seeing_column(summary_columns)
+        self._summary_columns = self.opsimdb.get_column_names('Summary')
+        self._set_seeing_column(self._summary_columns)
 
         # Set up self.dtype containg the dtype of the recarray we expect back from the SQL query.
         # Also setup baseQuery which is just the SELECT clause of the SQL query
@@ -132,7 +132,7 @@ class ObservationMetaDataGenerator(object):
         self.active_columns = []
         for column in self._user_interface_to_opsim:
             rec = self._user_interface_to_opsim[column]
-            if rec[0] in summary_columns:
+            if rec[0] in self._summary_columns:
                 self.active_columns.append(column)
                 dtypeList.append((rec[0], rec[2]))
                 if self.baseQuery != 'SELECT':
@@ -189,8 +189,7 @@ class ObservationMetaDataGenerator(object):
         is required. The angle ranges in the argument should be specified in degrees.
         """
 
-        summary_columns = self.opsimdb.get_column_names('Summary')
-        self._set_seeing_column(summary_columns)
+        self._set_seeing_column(self._summary_columns)
 
         query = self.baseQuery + ' FROM SUMMARY'
 

--- a/tests/testAllObjects.py
+++ b/tests/testAllObjects.py
@@ -8,9 +8,10 @@ from lsst.utils import getPackageDir
 from lsst.sims.catalogs.generation.db import CatalogDBObject
 from lsst.sims.catalogs.measures.instance import InstanceCatalog
 from lsst.sims.catUtils.exampleCatalogDefinitions import ObsStarCatalogBase
-#The following is to get the object ids in the registry
+# The following is to get the object ids in the registry
 import lsst.sims.catUtils.baseCatalogModels as bcm
 import os, inspect
+
 
 def failedOnFatboy(tracebackList):
     """
@@ -30,7 +31,7 @@ def failedOnFatboy(tracebackList):
         if 'sims' in item[0]:
             lastSimsDex = ix
 
-    if lastSimsDex<0:
+    if lastSimsDex < 0:
         return False
 
     if '_connect_to_engine' in tracebackList[lastSimsDex][2]:
@@ -76,7 +77,7 @@ class basicAccessTest(unittest.TestCase):
 
             obs_metadata = dbobj.testObservationMetaData
 
-            #Get results all at once
+            # Get results all at once
             try:
                 result = dbobj.query_columns(obs_metadata=obs_metadata)
             except:
@@ -94,15 +95,14 @@ class basicAccessTest(unittest.TestCase):
                 else:
                     raise
 
-
             ct_connected += 1
 
-            #Since there is only one chunck,
+            # Since there is only one chunck,
             try:
                 result = result.next()
             except StopIteration:
                 raise RuntimeError("No results for %s defined in %s"%(objname,
-                       inspect.getsourcefile(dbobj.__class__)))
+                                   inspect.getsourcefile(dbobj.__class__)))
             if objname.startswith('galaxy'):
                 TestCat.column_outputs = ['galid', 'raJ2000', 'decJ2000']
             else:
@@ -129,8 +129,8 @@ class basicAccessTest(unittest.TestCase):
         print 'This is just a tally so that you know how often that happened.'
         print 'successful connections: ', ct_connected
         print 'failed connections: ', ct_failed_connection
-        if len(list_of_failures)>0:
-            print 'objects that failed to connect: ',list_of_failures
+        if len(list_of_failures) > 0:
+            print 'objects that failed to connect: ', list_of_failures
 
     def testObsCat(self):
         objname = 'wdstars'
@@ -142,7 +142,7 @@ class basicAccessTest(unittest.TestCase):
             obs_metadata = dbobj.testObservationMetaData
             # To cover the central ~raft
             obs_metadata.boundLength = 0.4
-            obs_metadata.rotSkyPos=0.0
+            obs_metadata.rotSkyPos = 0.0
             cat = dbobj.getCatalog('obs_star_cat', obs_metadata)
             if os.path.exists(catName):
                 os.unlink(catName)
@@ -182,7 +182,10 @@ def suite():
 
     return unittest.TestSuite(suites)
 
+
 def run(shouldExit = False):
     utilsTests.run(suite(), shouldExit)
+
+
 if __name__ == "__main__":
     run(True)

--- a/tests/testAllObjects.py
+++ b/tests/testAllObjects.py
@@ -142,10 +142,7 @@ class basicAccessTest(unittest.TestCase):
             obs_metadata = dbobj.testObservationMetaData
             # To cover the central ~raft
             obs_metadata.boundLength = 0.4
-            opsMetadata = {'Opsim_rotskypos':(0., float),
-                           'pointingRA':(numpy.radians(obs_metadata.pointingRA), float),
-                           'pointingDec':(numpy.radians(obs_metadata.pointingDec), float)}
-            obs_metadata.phoSimMetaData = opsMetadata
+            obs_metadata.rotSkyPos=0.0
             cat = dbobj.getCatalog('obs_star_cat', obs_metadata)
             if os.path.exists(catName):
                 os.unlink(catName)

--- a/tests/testAstrometryMixins.py
+++ b/tests/testAstrometryMixins.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 
 import os
 import unittest
@@ -32,9 +32,9 @@ class parallaxTestCatalog(InstanceCatalog, AstrometryStars):
                       'properMotionRa', 'properMotionDec',
                       'radialVelocity', 'parallax']
 
-    transformations = {'raJ2000':numpy.degrees, 'decJ2000':numpy.degrees,
-                       'raObserved':numpy.degrees, 'decObserved':numpy.degrees,
-                       'properMotionRa':numpy.degrees, 'properMotionDec':numpy.degrees,
+    transformations = {'raJ2000':np.degrees, 'decJ2000':np.degrees,
+                       'raObserved':np.degrees, 'decObserved':np.degrees,
+                       'properMotionRa':np.degrees, 'properMotionDec':np.degrees,
                        'parallax':arcsecFromRadians}
 
     default_formats = {'f':'%.12f'}
@@ -52,7 +52,7 @@ class testCatalog(InstanceCatalog,AstrometryStars,CameraCoords):
     camera = camTestUtils.CameraWrapper().camera
     default_formats = {'f':'%.12f'}
 
-    delimiter = ';' #so that numpy.loadtxt can parse the chipNames which may contain commas
+    delimiter = ';' #so that np.loadtxt can parse the chipNames which may contain commas
                      #(see testClassMethods)
 
     default_columns = [('properMotionRa', 0., float),
@@ -133,7 +133,7 @@ class astrometryUnitTest(unittest.TestCase):
 
         self.obs_metadata=ObservationMetaData(pointingRA=200.0,
                                               pointingDec=-30.0,
-                                              rotSkyPos=numpy.degrees(1.0),
+                                              rotSkyPos=np.degrees(1.0),
                                               mjd=57388.0,
                                               boundType='circle',
                                               boundLength=0.05)
@@ -169,8 +169,8 @@ class astrometryUnitTest(unittest.TestCase):
 
         stars.write_catalog(catName)
 
-        dtypeList = [(name, numpy.float) for name in stars._column_outputs]
-        testData = numpy.genfromtxt(catName, delimiter=', ', dtype=numpy.dtype(dtypeList))
+        dtypeList = [(name, np.float) for name in stars._column_outputs]
+        testData = np.genfromtxt(catName, delimiter=', ', dtype=np.dtype(dtypeList))
 
         self.assertGreater(len(testData), 0)
 
@@ -192,8 +192,8 @@ class astrometryUnitTest(unittest.TestCase):
         galaxies.write_catalog(catName)
 
 
-        dtypeList = [(name, numpy.float) for name in galaxies._column_outputs]
-        testData = numpy.genfromtxt(catName, dtype=numpy.dtype(dtypeList), delimiter=';')
+        dtypeList = [(name, np.float) for name in galaxies._column_outputs]
+        testData = np.genfromtxt(catName, dtype=np.dtype(dtypeList), delimiter=';')
 
         self.assertGreater(len(testData), 0)
 
@@ -223,7 +223,7 @@ class astrometryUnitTest(unittest.TestCase):
                  ('xPix',float), ('yPix',float),
                  ('xFocalPlane',float), ('yFocalPlane',float)]
 
-        baselineData = numpy.loadtxt(catName, dtype=dtype, delimiter=';')
+        baselineData = np.loadtxt(catName, dtype=dtype, delimiter=';')
 
         self.assertGreater(len(baselineData), 0)
 
@@ -263,18 +263,18 @@ class astrometryUnitTest(unittest.TestCase):
                 zip(pixTest[0], pixTest[1], pixTestRaDec[0], pixTestRaDec[1],
                            baselineData['xPix'], baselineData['yPix']):
 
-            if not numpy.isnan(xx) and not numpy.isnan(yy):
+            if not np.isnan(xx) and not np.isnan(yy):
                 self.assertAlmostEqual(xxtest,xx,5)
                 self.assertAlmostEqual(yytest,yy,5)
                 self.assertAlmostEqual(xxra,xx,5)
                 self.assertAlmostEqual(yyra,yy,5)
             else:
-                self.assertTrue(numpy.isnan(xx))
-                self.assertTrue(numpy.isnan(yy))
-                self.assertTrue(numpy.isnan(xxra))
-                self.assertTrue(numpy.isnan(yyra))
-                self.assertTrue(numpy.isnan(xxtest))
-                self.assertTrue(numpy.isnan(yytest))
+                self.assertTrue(np.isnan(xx))
+                self.assertTrue(np.isnan(yy))
+                self.assertTrue(np.isnan(xxra))
+                self.assertTrue(np.isnan(yyra))
+                self.assertTrue(np.isnan(xxtest))
+                self.assertTrue(np.isnan(yytest))
 
 
         nameTest = chipNameFromPupilCoords(pupilTest[0], pupilTest[1],
@@ -316,7 +316,7 @@ class astrometryUnitTest(unittest.TestCase):
 
         cat.write_catalog(parallaxName)
 
-        data = numpy.genfromtxt(parallaxName,delimiter=',')
+        data = np.genfromtxt(parallaxName,delimiter=',')
         self.assertGreater(len(data), 0)
 
         epoch = cat.db_obj.epoch
@@ -325,20 +325,20 @@ class astrometryUnitTest(unittest.TestCase):
         for vv in data:
             #run the PALPY routines that actuall do astrometry `by hand' and compare
             #the results to the contents of the catalog
-            ra0 = numpy.radians(vv[0])
-            dec0 = numpy.radians(vv[1])
-            pmra = numpy.radians(vv[4])
-            pmdec = numpy.radians(vv[5])
+            ra0 = np.radians(vv[0])
+            dec0 = np.radians(vv[1])
+            pmra = np.radians(vv[4])
+            pmdec = np.radians(vv[5])
             rv = vv[6]
             px = vv[7]
             ra_apparent, dec_apparent = pal.mapqk(ra0, dec0, pmra, pmdec, px, rv, prms)
-            ra_apparent = numpy.array([ra_apparent])
-            dec_apparent = numpy.array([dec_apparent])
+            ra_apparent = np.array([ra_apparent])
+            dec_apparent = np.array([dec_apparent])
             raObserved, decObserved = _observedFromAppGeo(ra_apparent, dec_apparent,
                                                                  obs_metadata=cat.obs_metadata)
 
-            self.assertAlmostEqual(raObserved[0],numpy.radians(vv[2]),7)
-            self.assertAlmostEqual(decObserved[0],numpy.radians(vv[3]),7)
+            self.assertAlmostEqual(raObserved[0],np.radians(vv[2]),7)
+            self.assertAlmostEqual(decObserved[0],np.radians(vv[3]),7)
 
         if os.path.exists(parallaxName):
             os.unlink(parallaxName)

--- a/tests/testAstrometryMixins.py
+++ b/tests/testAstrometryMixins.py
@@ -130,14 +130,13 @@ class astrometryUnitTest(unittest.TestCase):
         #these would be set to meaningful values.  Because we are generating
         #an artificial set of inputs that must comport to the baseline SLALIB
         #inputs, these are set arbitrarily by hand
-        self.metadata['pointingRA'] = (numpy.radians(200.0), float)
-        self.metadata['pointingDec'] = (numpy.radians(-30.0), float)
-        self.metadata['Opsim_rotskypos'] = (1.0, float)
 
-        self.obs_metadata=ObservationMetaData(mjd=57388.0,
-                                     boundType='circle',
-                                     boundLength=0.05,
-                                     phoSimMetaData=self.metadata)
+        self.obs_metadata=ObservationMetaData(pointingRA=200.0,
+                                              pointingDec=-30.0,
+                                              rotSkyPos=numpy.degrees(1.0),
+                                              mjd=57388.0,
+                                              boundType='circle',
+                                              boundLength=0.05)
 
         self.cat = testCatalog(self.starDBObject, obs_metadata=self.obs_metadata)
         self.tol=1.0e-5

--- a/tests/testAstrometryMixins.py
+++ b/tests/testAstrometryMixins.py
@@ -2,8 +2,6 @@ import numpy as np
 
 import os
 import unittest
-import warnings
-import sys
 import math
 import palpy as pal
 import lsst.utils.tests as utilsTests
@@ -15,8 +13,8 @@ from lsst.sims.utils import _observedFromAppGeo, _pupilCoordsFromRaDec
 from lsst.sims.coordUtils import focalPlaneCoordsFromPupilCoords, _focalPlaneCoordsFromRaDec
 from lsst.sims.coordUtils import chipNameFromPupilCoords, _chipNameFromRaDec
 from lsst.sims.coordUtils import pixelCoordsFromPupilCoords, _pixelCoordsFromRaDec
-from lsst.sims.catalogs.generation.utils import myTestStars, makeStarTestDB, \
-                                                myTestGals, makeGalTestDB
+from lsst.sims.catalogs.generation.utils import (myTestStars, makeStarTestDB,
+                                                 myTestGals, makeGalTestDB)
 import lsst.afw.cameraGeom.testUtils as camTestUtils
 from lsst.sims.catUtils.mixins import AstrometryStars, AstrometryGalaxies, CameraCoords
 
@@ -24,36 +22,39 @@ from lsst.sims.catUtils.mixins import AstrometryStars, AstrometryGalaxies, Camer
 class AstrometryTestStars(myTestStars):
     database = 'AstrometryTestStarDatabase.db'
 
+
 class AstrometryTestGalaxies(myTestGals):
     database = 'AstrometryTestGalaxyDatabase.db'
+
 
 class parallaxTestCatalog(InstanceCatalog, AstrometryStars):
     column_outputs = ['raJ2000', 'decJ2000', 'raObserved', 'decObserved',
                       'properMotionRa', 'properMotionDec',
                       'radialVelocity', 'parallax']
 
-    transformations = {'raJ2000':np.degrees, 'decJ2000':np.degrees,
-                       'raObserved':np.degrees, 'decObserved':np.degrees,
-                       'properMotionRa':np.degrees, 'properMotionDec':np.degrees,
-                       'parallax':arcsecFromRadians}
+    transformations = {'raJ2000': np.degrees, 'decJ2000': np.degrees,
+                       'raObserved': np.degrees, 'decObserved': np.degrees,
+                       'properMotionRa': np.degrees, 'properMotionDec': np.degrees,
+                       'parallax': arcsecFromRadians}
 
-    default_formats = {'f':'%.12f'}
+    default_formats = {'f': '%.12f'}
 
-class testCatalog(InstanceCatalog,AstrometryStars,CameraCoords):
+
+class testCatalog(InstanceCatalog, AstrometryStars, CameraCoords):
     """
     A (somewhat meaningless) instance catalog class that will allow us
     to run the astrometry routines for testing purposes
     """
     catalog_type = 'test_stars'
-    column_outputs=['id','raICRS','decICRS',
-                   'x_pupil','y_pupil',
-                   'chipName', 'xPix', 'yPix','xFocalPlane','yFocalPlane']
-    #Needed to do camera coordinate transforms.
+    column_outputs = ['id', 'raICRS', 'decICRS',
+                      'x_pupil', 'y_pupil',
+                      'chipName', 'xPix', 'yPix', 'xFocalPlane', 'yFocalPlane']
+    # Needed to do camera coordinate transforms.
     camera = camTestUtils.CameraWrapper().camera
-    default_formats = {'f':'%.12f'}
+    default_formats = {'f': '%.12f'}
 
-    delimiter = ';' #so that np.loadtxt can parse the chipNames which may contain commas
-                     #(see testClassMethods)
+    delimiter = ';'  # so that np.loadtxt can parse the chipNames which may contain commas
+                     # (see testClassMethods)
 
     default_columns = [('properMotionRa', 0., float),
                        ('properMotionDec', 0., float),
@@ -75,6 +76,7 @@ class testStellarCatalog(InstanceCatalog, AstrometryStars, CameraCoords):
                       'chipName',
                       'raObserved', 'decObserved']
 
+
 class testGalaxyCatalog(InstanceCatalog, AstrometryGalaxies, CameraCoords):
     """
     Define a catalog of galaxies with all possible astrometric columns
@@ -87,6 +89,7 @@ class testGalaxyCatalog(InstanceCatalog, AstrometryGalaxies, CameraCoords):
                       'chipName', 'raObserved', 'decObserved']
 
     delimiter = '; '
+
 
 class astrometryUnitTest(unittest.TestCase):
     """
@@ -105,7 +108,7 @@ class astrometryUnitTest(unittest.TestCase):
         if os.path.exists(cls.starDBName):
             os.unlink(cls.starDBName)
         makeStarTestDB(filename=cls.starDBName,
-                      size=100000, seedVal=1, ramin=199.98*math.pi/180., dra=0.04*math.pi/180.)
+                       size=100000, seedVal=1, ramin=199.98*math.pi/180., dra=0.04*math.pi/180.)
 
         if os.path.exists(cls.galDBName):
             os.unlink(cls.galDBName)
@@ -123,37 +126,29 @@ class astrometryUnitTest(unittest.TestCase):
     def setUp(self):
         self.starDBObject = AstrometryTestStars()
         self.galaxyDBObject = AstrometryTestGalaxies()
-        self.metadata={}
 
-        #below are metadata values that need to be set in order for
-        #get_getFocalPlaneCoordinates to work.  If we had been querying the database,
-        #these would be set to meaningful values.  Because we are generating
-        #an artificial set of inputs that must comport to the baseline SLALIB
-        #inputs, these are set arbitrarily by hand
+        # below are metadata values that need to be set in order for
+        # get_getFocalPlaneCoordinates to work.  If we had been querying the database,
+        # these would be set to meaningful values.  Because we are generating
+        # an artificial set of inputs that must comport to the baseline SLALIB
+        # inputs, these are set arbitrarily by hand
 
-        self.obs_metadata=ObservationMetaData(pointingRA=200.0,
-                                              pointingDec=-30.0,
-                                              rotSkyPos=np.degrees(1.0),
-                                              mjd=57388.0,
-                                              boundType='circle',
-                                              boundLength=0.05)
+        self.obs_metadata = ObservationMetaData(pointingRA=200.0,
+                                                pointingDec=-30.0,
+                                                rotSkyPos=np.degrees(1.0),
+                                                mjd=57388.0,
+                                                boundType='circle',
+                                                boundLength=0.05)
 
         self.cat = testCatalog(self.starDBObject, obs_metadata=self.obs_metadata)
-        self.tol=1.0e-5
-
-    @classmethod
-    def tearDownClass(cls):
-        if os.path.exists('AstrometryTestDatabase.db'):
-            os.unlink('AstrometryTestDatabase.db')
+        self.tol = 1.0e-5
 
     def tearDown(self):
         del self.starDBObject
         del self.galaxyDBObject
         del self.cat
         del self.obs_metadata
-        del self.metadata
         del self.tol
-
 
     def testWritingOfStars(self):
         """
@@ -191,7 +186,6 @@ class astrometryUnitTest(unittest.TestCase):
         galaxies.delimiter = ';'
         galaxies.write_catalog(catName)
 
-
         dtypeList = [(name, np.float) for name in galaxies._column_outputs]
         testData = np.genfromtxt(catName, dtype=np.dtype(dtypeList), delimiter=';')
 
@@ -199,8 +193,6 @@ class astrometryUnitTest(unittest.TestCase):
 
         if os.path.exists(catName):
             os.unlink(catName)
-
-
 
     def testUtilityMethods(self):
         """
@@ -217,25 +209,25 @@ class astrometryUnitTest(unittest.TestCase):
 
         self.cat.write_catalog(catName)
 
-        dtype = [('id',int),
-                 ('raICRS',float), ('decICRS',float),
-                 ('x_pupil',float), ('y_pupil',float), ('chipName',str,11),
-                 ('xPix',float), ('yPix',float),
-                 ('xFocalPlane',float), ('yFocalPlane',float)]
+        dtype = [('id', int),
+                 ('raICRS', float), ('decICRS', float),
+                 ('x_pupil', float), ('y_pupil', float), ('chipName', str, 11),
+                 ('xPix', float), ('yPix', float),
+                 ('xFocalPlane', float), ('yFocalPlane', float)]
 
         baselineData = np.loadtxt(catName, dtype=dtype, delimiter=';')
 
         self.assertGreater(len(baselineData), 0)
 
         pupilTest = _pupilCoordsFromRaDec(baselineData['raICRS'],
-                                              baselineData['decICRS'],
-                                              obs_metadata=self.obs_metadata,
-                                              epoch=2000.0)
+                                          baselineData['decICRS'],
+                                          obs_metadata=self.obs_metadata,
+                                          epoch=2000.0)
 
         for (xxtest, yytest, xx, yy) in \
                 zip(pupilTest[0], pupilTest[1], baselineData['x_pupil'], baselineData['y_pupil']):
-            self.assertAlmostEqual(xxtest,xx,6)
-            self.assertAlmostEqual(yytest,yy,6)
+            self.assertAlmostEqual(xxtest, xx, 6)
+            self.assertAlmostEqual(yytest, yy, 6)
 
         focalTest = focalPlaneCoordsFromPupilCoords(pupilTest[0], pupilTest[1], camera=self.cat.camera)
 
@@ -245,12 +237,12 @@ class astrometryUnitTest(unittest.TestCase):
 
         for (xxtest, yytest, xxra, yyra, xx, yy) in \
                 zip(focalTest[0], focalTest[1], focalRa[0], focalRa[1],
-                        baselineData['xFocalPlane'], baselineData['yFocalPlane']):
+                    baselineData['xFocalPlane'], baselineData['yFocalPlane']):
 
-            self.assertAlmostEqual(xxtest,xx,6)
-            self.assertAlmostEqual(yytest,yy,6)
-            self.assertAlmostEqual(xxra,xx,6)
-            self.assertAlmostEqual(yyra,yy,6)
+            self.assertAlmostEqual(xxtest, xx, 6)
+            self.assertAlmostEqual(yytest, yy, 6)
+            self.assertAlmostEqual(xxra, xx, 6)
+            self.assertAlmostEqual(yyra, yy, 6)
 
         pixTest = pixelCoordsFromPupilCoords(pupilTest[0], pupilTest[1], camera=self.cat.camera)
 
@@ -261,13 +253,13 @@ class astrometryUnitTest(unittest.TestCase):
 
         for (xxtest, yytest, xxra, yyra, xx, yy) in \
                 zip(pixTest[0], pixTest[1], pixTestRaDec[0], pixTestRaDec[1],
-                           baselineData['xPix'], baselineData['yPix']):
+                    baselineData['xPix'], baselineData['yPix']):
 
             if not np.isnan(xx) and not np.isnan(yy):
-                self.assertAlmostEqual(xxtest,xx,5)
-                self.assertAlmostEqual(yytest,yy,5)
-                self.assertAlmostEqual(xxra,xx,5)
-                self.assertAlmostEqual(yyra,yy,5)
+                self.assertAlmostEqual(xxtest, xx, 5)
+                self.assertAlmostEqual(yytest, yy, 5)
+                self.assertAlmostEqual(xxra, xx, 5)
+                self.assertAlmostEqual(yyra, yy, 5)
             else:
                 self.assertTrue(np.isnan(xx))
                 self.assertTrue(np.isnan(yy))
@@ -275,7 +267,6 @@ class astrometryUnitTest(unittest.TestCase):
                 self.assertTrue(np.isnan(yyra))
                 self.assertTrue(np.isnan(xxtest))
                 self.assertTrue(np.isnan(yytest))
-
 
         nameTest = chipNameFromPupilCoords(pupilTest[0], pupilTest[1],
                                            camera=self.cat.camera)
@@ -286,15 +277,14 @@ class astrometryUnitTest(unittest.TestCase):
 
         for (ntest, nra, ncontrol) in zip(nameTest, nameRA, baselineData['chipName']):
             if ncontrol != 'None':
-                self.assertEqual(ntest,ncontrol)
-                self.assertEqual(nra,ncontrol)
+                self.assertEqual(ntest, ncontrol)
+                self.assertEqual(nra, ncontrol)
             else:
                 self.assertTrue(ntest is None)
                 self.assertTrue(nra is None)
 
         if os.path.exists(catName):
             os.unlink(catName)
-
 
     def testParallax(self):
         """
@@ -305,8 +295,8 @@ class astrometryUnitTest(unittest.TestCase):
         generating code correctly applied the transformations.
         """
 
-        #create and write a catalog that performs astrometric transformations
-        #on a cartoon star database
+        # create and write a catalog that performs astrometric transformations
+        # on a cartoon star database
         cat = parallaxTestCatalog(self.starDBObject, obs_metadata=self.obs_metadata)
         parallaxName = os.path.join(getPackageDir('sims_catUtils'), 'tests',
                                     'scratchSpace', 'parallaxCatalog.sav')
@@ -316,15 +306,15 @@ class astrometryUnitTest(unittest.TestCase):
 
         cat.write_catalog(parallaxName)
 
-        data = np.genfromtxt(parallaxName,delimiter=',')
+        data = np.genfromtxt(parallaxName, delimiter=',')
         self.assertGreater(len(data), 0)
 
         epoch = cat.db_obj.epoch
         mjd = cat.obs_metadata.mjd
         prms = pal.mappa(epoch, mjd.TDB)
         for vv in data:
-            #run the PALPY routines that actuall do astrometry `by hand' and compare
-            #the results to the contents of the catalog
+            # run the PALPY routines that actuall do astrometry `by hand' and compare
+            # the results to the contents of the catalog
             ra0 = np.radians(vv[0])
             dec0 = np.radians(vv[1])
             pmra = np.radians(vv[4])
@@ -335,13 +325,14 @@ class astrometryUnitTest(unittest.TestCase):
             ra_apparent = np.array([ra_apparent])
             dec_apparent = np.array([dec_apparent])
             raObserved, decObserved = _observedFromAppGeo(ra_apparent, dec_apparent,
-                                                                 obs_metadata=cat.obs_metadata)
+                                                          obs_metadata=cat.obs_metadata)
 
-            self.assertAlmostEqual(raObserved[0],np.radians(vv[2]),7)
-            self.assertAlmostEqual(decObserved[0],np.radians(vv[3]),7)
+            self.assertAlmostEqual(raObserved[0], np.radians(vv[2]), 7)
+            self.assertAlmostEqual(decObserved[0], np.radians(vv[3]), 7)
 
         if os.path.exists(parallaxName):
             os.unlink(parallaxName)
+
 
 def suite():
     utilsTests.init()
@@ -349,8 +340,9 @@ def suite():
     suites += unittest.makeSuite(astrometryUnitTest)
     return unittest.TestSuite(suites)
 
+
 def run(shouldExit=False):
-    utilsTests.run(suite(),shouldExit)
+    utilsTests.run(suite(), shouldExit)
 
 if __name__ == "__main__":
     run(True)

--- a/tests/testObservationMetaDataGenerator.py
+++ b/tests/testObservationMetaDataGenerator.py
@@ -487,7 +487,7 @@ class ObsMetaDataGenMockOpsimTest(unittest.TestCase):
         with self.assertRaises(RuntimeError) as context:
             results = self.obs_meta_gen.getObservationMetaData(rotSkyPos=(27.0, 112.0))
         self.assertIn("You have asked ObservationMetaDataGenerator to SELECT",
-                      context.exception.message)
+                      context.exception.args[0])
 
     def testIncompletDB(self):
         """
@@ -528,7 +528,7 @@ class ObsMetaDataGenMockOpsimTest(unittest.TestCase):
         with self.assertRaises(RuntimeError) as context:
             results = incomplete_obs_gen.getObservationMetaData(telescopeFilter='r')
         self.assertIn("ObservationMetaDataGenerator requires that the database",
-                      context.exception.message)
+                      context.exception.args[0])
 
         if os.path.exists(opsim_db_name):
             os.unlink(opsim_db_name)

--- a/tests/testObservationMetaDataGenerator.py
+++ b/tests/testObservationMetaDataGenerator.py
@@ -5,13 +5,11 @@ import numpy
 import lsst.utils.tests as utilsTests
 from lsst.sims.catUtils.utils import ObservationMetaDataGenerator
 from lsst.sims.utils import CircleBounds, BoxBounds, altAzPaFromRaDec
-from lsst.sims.catalogs.generation.db import CatalogDBObject
-from lsst.sims.catUtils.baseCatalogModels import GalaxyBulgeObj, GalaxyDiskObj, GalaxyAgnObj, StarObj
+from lsst.sims.utils import ObservationMetaData
 from lsst.sims.catUtils.exampleCatalogDefinitions import PhoSimCatalogSersic2D
-from lsst.sims.catUtils.utils import SearchReversion, testGalaxyBulgeDBObj
+from lsst.sims.catUtils.utils import testGalaxyBulgeDBObj
 from lsst.sims.catalogs.generation.utils import makePhoSimTestDB
 from lsst.utils import getPackageDir
-
 
 
 def get_val_from_obs(tag, obs):
@@ -73,13 +71,13 @@ def get_val_from_rec(tag, rec):
     elif tag == 'skyBrightness':
         return rec['filtSkyBrightness']
     elif tag in ('fieldRA', 'fieldDec', 'moonRA', 'moonDec',
-    'rotSkyPos', 'sunAlt', 'moonAlt', 'dist2Moon', 'altitude',
-    'azimuth'):
+                 'rotSkyPos', 'sunAlt', 'moonAlt', 'dist2Moon', 'altitude',
+                 'azimuth'):
 
         return numpy.degrees(rec[tag])
 
-
     return rec[tag]
+
 
 class ObservationMetaDataGeneratorTest(unittest.TestCase):
 
@@ -93,7 +91,7 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
                                     'Unrefracted_RA', 'Unrefracted_Dec')
 
         dbPath = os.path.join(getPackageDir('sims_data'),
-                             'OpSimData/opsimblitz1_1133_sqlite.db')
+                              'OpSimData/opsimblitz1_1133_sqlite.db')
         self.gen = ObservationMetaDataGenerator(database=dbPath,
                                                 driver='sqlite')
 
@@ -103,8 +101,7 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
         """
         gen = self.gen
         self.assertRaises(RuntimeError, gen.getObservationMetaData)
-        self.assertRaises(RuntimeError, gen.getObservationMetaData,fieldRA=(1.0, 2.0, 3.0))
-
+        self.assertRaises(RuntimeError, gen.getObservationMetaData, fieldRA=(1.0, 2.0, 3.0))
 
     def testQueryOnRanges(self):
         """
@@ -122,15 +119,14 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
         # This was generated with a separate script which printed
         # the median and maximum values of all of the quantities
         # in our test opsim database
-        bounds = [
-        ('obsHistID',(5973, 7000)),
-        ('fieldRA',(numpy.degrees(1.370916), numpy.degrees(1.40))),
-        ('rawSeeing',(0.728562, 0.9)),
-        ('seeing', (0.7, 0.9)),
-        ('dist2Moon',(numpy.degrees(1.570307), numpy.degrees(1.9))),
-        ('expMJD',(49367.129396, 49370.0)),
-        ('m5',(22.815249, 23.0)),
-        ('skyBrightness',(19.017605, 19.5))]
+        bounds = [('obsHistID', (5973, 7000)),
+                  ('fieldRA', (numpy.degrees(1.370916), numpy.degrees(1.40))),
+                  ('rawSeeing', (0.728562, 0.9)),
+                  ('seeing', (0.7, 0.9)),
+                  ('dist2Moon', (numpy.degrees(1.570307), numpy.degrees(1.9))),
+                  ('expMJD', (49367.129396, 49370.0)),
+                  ('m5', (22.815249, 23.0)),
+                  ('skyBrightness', (19.017605, 19.5))]
 
         # test querying on a single column
         for line in bounds:
@@ -148,7 +144,6 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
                 self.assertLess(val, line[1][1], msg=msg)
 
         # test querying on two columns at once
-        ct = 0
         for ix in range(len(bounds)):
             tag1 = bounds[ix][0]
 
@@ -169,20 +164,18 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
                     self.assertGreater(v2, bounds[jx][1][0], msg=msg)
                     self.assertLess(v2, bounds[jx][1][1], msg=msg)
 
-
     def testOpSimQueryOnRanges(self):
         """
         Test that getOpimRecords() returns correct results
         """
-        bounds = [
-        ('obsHistID',(5973, 7000)),
-        ('fieldRA',(numpy.degrees(1.370916), numpy.degrees(1.40))),
-        ('rawSeeing',(0.728562, 0.9)),
-        ('seeing', (0.7, 0.9)),
-        ('dist2Moon',(numpy.degrees(1.570307), numpy.degrees(1.9))),
-        ('expMJD',(49367.129396, 49370.0)),
-        ('m5',(22.815249, 23.0)),
-        ('skyBrightness',(19.017605, 19.5)),]
+        bounds = [('obsHistID', (5973, 7000)),
+                  ('fieldRA', (numpy.degrees(1.370916), numpy.degrees(1.40))),
+                  ('rawSeeing', (0.728562, 0.9)),
+                  ('seeing', (0.7, 0.9)),
+                  ('dist2Moon', (numpy.degrees(1.570307), numpy.degrees(1.9))),
+                  ('expMJD', (49367.129396, 49370.0)),
+                  ('m5', (22.815249, 23.0)),
+                  ('skyBrightness', (19.017605, 19.5))]
 
         for line in bounds:
             tag = line[0]
@@ -218,25 +211,24 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
         """
         gen = self.gen
 
-        bounds = [
-        ('obsHistID',5973),
-        ('expDate',1220779),
-        ('fieldRA',numpy.degrees(1.370916)),
-        ('fieldDec',numpy.degrees(-0.456238)),
-        ('moonRA',numpy.degrees(2.914132)),
-        ('moonDec',numpy.degrees(0.06305)),
-        ('rotSkyPos',numpy.degrees(3.116656)),
-        ('telescopeFilter','i'),
-        ('rawSeeing',0.728562),
-        ('seeing', 0.88911899999999999),
-        ('sunAlt',numpy.degrees(-0.522905)),
-        ('moonAlt',numpy.degrees(0.099096)),
-        ('dist2Moon',numpy.degrees(1.570307)),
-        ('moonPhase',52.2325),
-        ('expMJD',49367.129396),
-        ('visitExpTime',30.0),
-        ('m5',22.815249),
-        ('skyBrightness',19.017605)]
+        bounds = [('obsHistID', 5973),
+                  ('expDate', 1220779),
+                  ('fieldRA', numpy.degrees(1.370916)),
+                  ('fieldDec', numpy.degrees(-0.456238)),
+                  ('moonRA', numpy.degrees(2.914132)),
+                  ('moonDec', numpy.degrees(0.06305)),
+                  ('rotSkyPos', numpy.degrees(3.116656)),
+                  ('telescopeFilter', 'i'),
+                  ('rawSeeing', 0.728562),
+                  ('seeing', 0.88911899999999999),
+                  ('sunAlt', numpy.degrees(-0.522905)),
+                  ('moonAlt', numpy.degrees(0.099096)),
+                  ('dist2Moon', numpy.degrees(1.570307)),
+                  ('moonPhase', 52.2325),
+                  ('expMJD', 49367.129396),
+                  ('visitExpTime', 30.0),
+                  ('m5', 22.815249),
+                  ('skyBrightness', 19.017605)]
 
         for ii in range(len(bounds)):
             tag = bounds[ii][0]
@@ -253,26 +245,24 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
         Test that querying OpSim records for exact values works
         """
 
-        bounds = [
-        ('obsHistID',5973),
-        ('expDate',1220779),
-        ('fieldRA',numpy.degrees(1.370916)),
-        ('fieldDec',numpy.degrees(-0.456238)),
-        ('moonRA',numpy.degrees(2.914132)),
-        ('moonDec',numpy.degrees(0.06305)),
-        ('rotSkyPos',numpy.degrees(3.116656)),
-        ('telescopeFilter','i'),
-        ('rawSeeing',0.728562),
-        ('seeing', 0.88911899999999999),
-        ('sunAlt',numpy.degrees(-0.522905)),
-        ('moonAlt',numpy.degrees(0.099096)),
-        ('dist2Moon',numpy.degrees(1.570307)),
-        ('moonPhase',52.2325),
-        ('expMJD',49367.129396),
-        ('visitExpTime',30.0),
-        ('m5',22.815249),
-        ('skyBrightness',19.017605)]
-
+        bounds = [('obsHistID', 5973),
+                  ('expDate', 1220779),
+                  ('fieldRA', numpy.degrees(1.370916)),
+                  ('fieldDec', numpy.degrees(-0.456238)),
+                  ('moonRA', numpy.degrees(2.914132)),
+                  ('moonDec', numpy.degrees(0.06305)),
+                  ('rotSkyPos', numpy.degrees(3.116656)),
+                  ('telescopeFilter', 'i'),
+                  ('rawSeeing', 0.728562),
+                  ('seeing', 0.88911899999999999),
+                  ('sunAlt', numpy.degrees(-0.522905)),
+                  ('moonAlt', numpy.degrees(0.099096)),
+                  ('dist2Moon', numpy.degrees(1.570307)),
+                  ('moonPhase', 52.2325),
+                  ('expMJD', 49367.129396),
+                  ('visitExpTime', 30.0),
+                  ('m5', 22.815249),
+                  ('skyBrightness', 19.017605)]
 
         for line in bounds:
             tag = line[0]
@@ -298,6 +288,7 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
 
         for pp in pointing_list:
             obs = local_gen.ObservationMetaDataFromPointing(pp)
+            self.assertIsInstance(obs, ObservationMetaData)
 
     def testQueryLimit(self):
         """
@@ -402,7 +393,7 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
         catName = 'testPhoSimFromObsMetaDataGenerator.txt'
         if os.path.exists(dbName):
             os.unlink(dbName)
-        _ = makePhoSimTestDB(filename=dbName)
+        makePhoSimTestDB(filename=dbName)
         bulgeDB = testGalaxyBulgeDBObj(driver='sqlite', database=dbName)
         gen = self.gen
         results = gen.getObservationMetaData(fieldRA=numpy.degrees(1.370916),
@@ -416,7 +407,7 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
             for line in lines:
                 words = line.split()
                 if words[0] == 'object':
-                   break
+                    break
                 header_entries.append(words[0])
 
             for column in self.gen._opsim_to_phosim:

--- a/tests/testObservationMetaDataGenerator.py
+++ b/tests/testObservationMetaDataGenerator.py
@@ -1,7 +1,7 @@
 from __future__ import with_statement
 import os
 import unittest
-import numpy
+import numpy as np
 import lsst.utils.tests as utilsTests
 from lsst.sims.catUtils.utils import ObservationMetaDataGenerator
 from lsst.sims.utils import CircleBounds, BoxBounds, altAzPaFromRaDec
@@ -30,7 +30,7 @@ def get_val_from_obs(tag, obs):
         return obs.mjd.TAI
     elif tag == 'airmass':
         alt, az, pa = altAzPaFromRaDec(obs.pointingRA, obs.pointingDec, obs)
-        return 1.0/(numpy.cos(numpy.pi/2.0-numpy.radians(alt)))
+        return 1.0/(np.cos(np.pi/2.0-np.radians(alt)))
     elif tag == 'm5':
         return obs.m5[obs.bandpass]
     elif tag == 'skyBrightness':
@@ -74,7 +74,7 @@ def get_val_from_rec(tag, rec):
                  'rotSkyPos', 'sunAlt', 'moonAlt', 'dist2Moon', 'altitude',
                  'azimuth'):
 
-        return numpy.degrees(rec[tag])
+        return np.degrees(rec[tag])
 
     return rec[tag]
 
@@ -120,10 +120,10 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
         # the median and maximum values of all of the quantities
         # in our test opsim database
         bounds = [('obsHistID', (5973, 7000)),
-                  ('fieldRA', (numpy.degrees(1.370916), numpy.degrees(1.40))),
+                  ('fieldRA', (np.degrees(1.370916), np.degrees(1.40))),
                   ('rawSeeing', (0.728562, 0.9)),
                   ('seeing', (0.7, 0.9)),
-                  ('dist2Moon', (numpy.degrees(1.570307), numpy.degrees(1.9))),
+                  ('dist2Moon', (np.degrees(1.570307), np.degrees(1.9))),
                   ('expMJD', (49367.129396, 49370.0)),
                   ('m5', (22.815249, 23.0)),
                   ('skyBrightness', (19.017605, 19.5))]
@@ -169,10 +169,10 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
         Test that getOpimRecords() returns correct results
         """
         bounds = [('obsHistID', (5973, 7000)),
-                  ('fieldRA', (numpy.degrees(1.370916), numpy.degrees(1.40))),
+                  ('fieldRA', (np.degrees(1.370916), np.degrees(1.40))),
                   ('rawSeeing', (0.728562, 0.9)),
                   ('seeing', (0.7, 0.9)),
-                  ('dist2Moon', (numpy.degrees(1.570307), numpy.degrees(1.9))),
+                  ('dist2Moon', (np.degrees(1.570307), np.degrees(1.9))),
                   ('expMJD', (49367.129396, 49370.0)),
                   ('m5', (22.815249, 23.0)),
                   ('skyBrightness', (19.017605, 19.5))]
@@ -213,17 +213,17 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
 
         bounds = [('obsHistID', 5973),
                   ('expDate', 1220779),
-                  ('fieldRA', numpy.degrees(1.370916)),
-                  ('fieldDec', numpy.degrees(-0.456238)),
-                  ('moonRA', numpy.degrees(2.914132)),
-                  ('moonDec', numpy.degrees(0.06305)),
-                  ('rotSkyPos', numpy.degrees(3.116656)),
+                  ('fieldRA', np.degrees(1.370916)),
+                  ('fieldDec', np.degrees(-0.456238)),
+                  ('moonRA', np.degrees(2.914132)),
+                  ('moonDec', np.degrees(0.06305)),
+                  ('rotSkyPos', np.degrees(3.116656)),
                   ('telescopeFilter', 'i'),
                   ('rawSeeing', 0.728562),
                   ('seeing', 0.88911899999999999),
-                  ('sunAlt', numpy.degrees(-0.522905)),
-                  ('moonAlt', numpy.degrees(0.099096)),
-                  ('dist2Moon', numpy.degrees(1.570307)),
+                  ('sunAlt', np.degrees(-0.522905)),
+                  ('moonAlt', np.degrees(0.099096)),
+                  ('dist2Moon', np.degrees(1.570307)),
                   ('moonPhase', 52.2325),
                   ('expMJD', 49367.129396),
                   ('visitExpTime', 30.0),
@@ -247,17 +247,17 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
 
         bounds = [('obsHistID', 5973),
                   ('expDate', 1220779),
-                  ('fieldRA', numpy.degrees(1.370916)),
-                  ('fieldDec', numpy.degrees(-0.456238)),
-                  ('moonRA', numpy.degrees(2.914132)),
-                  ('moonDec', numpy.degrees(0.06305)),
-                  ('rotSkyPos', numpy.degrees(3.116656)),
+                  ('fieldRA', np.degrees(1.370916)),
+                  ('fieldDec', np.degrees(-0.456238)),
+                  ('moonRA', np.degrees(2.914132)),
+                  ('moonDec', np.degrees(0.06305)),
+                  ('rotSkyPos', np.degrees(3.116656)),
                   ('telescopeFilter', 'i'),
                   ('rawSeeing', 0.728562),
                   ('seeing', 0.88911899999999999),
-                  ('sunAlt', numpy.degrees(-0.522905)),
-                  ('moonAlt', numpy.degrees(0.099096)),
-                  ('dist2Moon', numpy.degrees(1.570307)),
+                  ('sunAlt', np.degrees(-0.522905)),
+                  ('moonAlt', np.degrees(0.099096)),
+                  ('dist2Moon', np.degrees(1.570307)),
                   ('moonPhase', 52.2325),
                   ('expMJD', 49367.129396),
                   ('visitExpTime', 30.0),
@@ -280,7 +280,7 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
         out
         """
 
-        pointing_list = self.gen.getOpSimRecords(fieldRA=numpy.degrees(1.370916))
+        pointing_list = self.gen.getOpSimRecords(fieldRA=np.degrees(1.370916))
         self.assertGreater(len(pointing_list), 1)
         local_gen = ObservationMetaDataGenerator()
         obs_list = local_gen.ObservationMetaDataFromPointingArray(pointing_list)
@@ -296,7 +296,7 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
         that limit is respected
         """
         gen = self.gen
-        results = gen.getObservationMetaData(fieldRA=(numpy.degrees(1.370916), numpy.degrees(1.5348635)),
+        results = gen.getObservationMetaData(fieldRA=(np.degrees(1.370916), np.degrees(1.5348635)),
                                              limit=20)
         self.assertEqual(len(results), 20)
 
@@ -305,7 +305,7 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
         Test that queries on the filter work.
         """
         gen = self.gen
-        results = gen.getObservationMetaData(fieldRA=numpy.degrees(1.370916), telescopeFilter='i')
+        results = gen.getObservationMetaData(fieldRA=np.degrees(1.370916), telescopeFilter='i')
         ct = 0
         for obs_metadata in results:
             self.assertAlmostEqual(obs_metadata._pointingRA, 1.370916)
@@ -324,7 +324,7 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
         gen = self.gen
 
         # Test a cirlce with a specified radius
-        results = gen.getObservationMetaData(fieldRA=numpy.degrees(1.370916),
+        results = gen.getObservationMetaData(fieldRA=np.degrees(1.370916),
                                              telescopeFilter='i',
                                              boundLength=0.9)
         ct = 0
@@ -338,9 +338,9 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
             self.assertLess(obs_metadata.bounds.radiusdeg, 0.95)
 
             self.assertAlmostEqual(obs_metadata.bounds.RA,
-                                   numpy.radians(obs_metadata.pointingRA), 5)
+                                   np.radians(obs_metadata.pointingRA), 5)
             self.assertAlmostEqual(obs_metadata.bounds.DEC,
-                                   numpy.radians(obs_metadata.pointingDec), 5)
+                                   np.radians(obs_metadata.pointingDec), 5)
             ct += 1
 
         # Make sure that some ObservationMetaData were tested
@@ -348,7 +348,7 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
 
         boundLengthList = [1.2, (1.2, 0.6)]
         for boundLength in boundLengthList:
-            results = gen.getObservationMetaData(fieldRA=numpy.degrees(1.370916),
+            results = gen.getObservationMetaData(fieldRA=np.degrees(1.370916),
                                                  telescopeFilter='i',
                                                  boundType='box',
                                                  boundLength=boundLength)
@@ -374,8 +374,8 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
 
                 self.assertAlmostEqual(obs_metadata.bounds.DECmaxDeg, DECdeg+ddec, 10)
 
-                self.assertAlmostEqual(obs_metadata.bounds.RA, numpy.radians(obs_metadata.pointingRA), 5)
-                self.assertAlmostEqual(obs_metadata.bounds.DEC, numpy.radians(obs_metadata.pointingDec), 5)
+                self.assertAlmostEqual(obs_metadata.bounds.RA, np.radians(obs_metadata.pointingRA), 5)
+                self.assertAlmostEqual(obs_metadata.bounds.DEC, np.radians(obs_metadata.pointingDec), 5)
 
                 ct += 1
 
@@ -396,7 +396,7 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
         makePhoSimTestDB(filename=dbName)
         bulgeDB = testGalaxyBulgeDBObj(driver='sqlite', database=dbName)
         gen = self.gen
-        results = gen.getObservationMetaData(fieldRA=numpy.degrees(1.370916),
+        results = gen.getObservationMetaData(fieldRA=np.degrees(1.370916),
                                              telescopeFilter='i')
         testCat = PhoSimCatalogSersic2D(bulgeDB, obs_metadata=results[0])
         testCat.write_catalog(catName)

--- a/tests/testObservationMetaDataGenerator.py
+++ b/tests/testObservationMetaDataGenerator.py
@@ -193,6 +193,22 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
                 self.assertGreater(val, line[1][0], msg=msg)
                 self.assertLess(val, line[1][1], msg=msg)
 
+        for ix in range(len(bounds)):
+            tag1 = bounds[ix][0]
+            for jx in range(ix+1, len(bounds)):
+                tag2 = bounds[jx][0]
+                args = {tag1: bounds[ix][1], tag2: bounds[jx][1]}
+                results = self.gen.getOpSimRecords(**args)
+                msg = 'failed while querying %s and %s' % (tag1, tag2)
+                self.assertGreater(len(results), 0)
+                for rec in results:
+                    v1 = get_val_from_rec(tag1, rec)
+                    v2 = get_val_from_rec(tag2, rec)
+                    self.assertGreater(v1, bounds[ix][1][0], msg=msg)
+                    self.assertLess(v1, bounds[ix][1][1], msg=msg)
+                    self.assertGreater(v2, bounds[jx][1][0], msg=msg)
+                    self.assertLess(v2, bounds[jx][1][1], msg=msg)
+
     def testQueryExactValues(self):
         """
         Test that ObservationMetaData returned by a query demanding an exact value do,

--- a/tests/testObservationMetaDataGenerator.py
+++ b/tests/testObservationMetaDataGenerator.py
@@ -403,9 +403,9 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
                    break
                 header_entries.append(words[0])
 
-            for column in self.gen.columnMapping:
-                if column[2] is not None:
-                    self.assertIn(column[2], header_entries)
+            for column in self.gen._opsim_to_phosim:
+                new_name = self.gen._opsim_to_phosim[column][0]
+                self.assertIn(new_name, header_entries)
 
         if os.path.exists(catName):
             os.unlink(catName)

--- a/tests/testObservationMetaDataGenerator.py
+++ b/tests/testObservationMetaDataGenerator.py
@@ -162,10 +162,12 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
                 msg = "failed querying %s and %s" % (tag1, tag2)
                 self.assertGreater(len(results), 0, msg=msg)
                 for obs in results:
-                    self.assertGreater(get_val_from_obs(tag1, obs), bounds[ix][1][0], msg=msg)
-                    self.assertLess(get_val_from_obs(tag1, obs), bounds[ix][1][1], msg=msg)
-                    self.assertGreater(get_val_from_obs(tag2, obs), bounds[jx][1][0], msg=msg)
-                    self.assertLess(get_val_from_obs(tag2, obs), bounds[jx][1][1], msg=msg)
+                    v1 = get_val_from_obs(tag1, obs)
+                    v2 = get_val_from_obs(tag2, obs)
+                    self.assertGreater(v1, bounds[ix][1][0], msg=msg)
+                    self.assertLess(v1, bounds[ix][1][1], msg=msg)
+                    self.assertGreater(v2, bounds[jx][1][0], msg=msg)
+                    self.assertLess(v2, bounds[jx][1][1], msg=msg)
 
 
     def testOpSimQueryOnRanges(self):

--- a/tests/testObservationMetaDataGenerator.py
+++ b/tests/testObservationMetaDataGenerator.py
@@ -8,60 +8,10 @@ from lsst.sims.utils import CircleBounds, BoxBounds
 from lsst.sims.catalogs.generation.db import CatalogDBObject
 from lsst.sims.catUtils.baseCatalogModels import GalaxyBulgeObj, GalaxyDiskObj, GalaxyAgnObj, StarObj
 from lsst.sims.catUtils.exampleCatalogDefinitions import PhoSimCatalogSersic2D
+from lsst.sims.catUtils.utils import SearchReversion, testGalaxyBulgeDBObj
 from lsst.sims.catalogs.generation.utils import makePhoSimTestDB
 from lsst.utils import getPackageDir
 
-#28 January 2015
-#SearchReversion and testGalaxyBulge are duplicated from testPhoSimCatalogs.py
-#There is already a pull request outstanding that will move
-#these classes to a testUtils.py file in sims_catUtils/../utils/
-#Once that pull request is merged, I will clean this file up
-#and remove the duplicated code.
-class SearchReversion(CatalogDBObject):
-    """
-    This is a mixin which is used below to force the galaxy CatalogDBObjects created for
-    this unittest to use the methods defined in the CatalogDBObject class.  This is because
-    we are using classes which inherit from GalaxyTileObj but do not actually want to use
-    the tiled query routines.
-
-    We also use this mixin for our stellar database object.  This is because StarObj
-    implements a query search based on htmid, which the test database for this unit
-    test will not have.
-    """
-
-    def _get_column_query(self, *args, **kwargs):
-        return CatalogDBObject._get_column_query(self,*args, **kwargs)
-
-    def _final_pass(self, *args, **kwargs):
-        return CatalogDBObject._final_pass(self,*args, **kwargs)
-
-    def query_columns(self, *args, **kwargs):
-        return CatalogDBObject.query_columns(self, *args, **kwargs)
-
-class testGalaxyBulge(SearchReversion, GalaxyBulgeObj):
-    """
-    A class for storing galaxy bulges
-    """
-    objid = 'phoSimTestBulges'
-    objectTypeId = 88
-
-    #The code below makes sure that we can store RA, Dec in degrees
-    #in the database but use radians in our calculations.
-    #We had to overwrite the original columns list because
-    #GalaxyTileObject daughter classes assume that RA and Dec are stored
-    #in radians in the database.  This is a side effect of the tiling
-    #scheme used to cover the whole sky.
-
-    columns = GalaxyBulgeObj.columns
-    _to_remove = []
-    for entry in columns:
-        if entry[0] == 'raJ2000' or entry[0] == 'decJ2000':
-            _to_remove.append(entry)
-    for target in _to_remove:
-        columns.remove(target)
-
-    columns.append(('raJ2000','ra*PI()/180.'))
-    columns.append(('decJ2000','dec*PI()/180.'))
 
 class ObservationMetaDataGeneratorTest(unittest.TestCase):
 
@@ -386,7 +336,7 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
         if os.path.exists(dbName):
             os.unlink(dbName)
         _ = makePhoSimTestDB(filename=dbName)
-        bulgeDB = testGalaxyBulge(driver='sqlite', database=dbName)
+        bulgeDB = testGalaxyBulgeDBObj(driver='sqlite', database=dbName)
         gen = self.gen
         results = gen.getObservationMetaData(fieldRA=numpy.degrees(1.370916),
                                              telescopeFilter='i')

--- a/tests/testObservationMetaDataGenerator.py
+++ b/tests/testObservationMetaDataGenerator.py
@@ -283,6 +283,22 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
             for rec in results:
                 self.assertEqual(get_val_from_rec(tag, rec), line[1], msg=msg)
 
+    def testPassInOtherQuery(self):
+        """
+        Test that you can pass OpSim pointings generated from another source
+        into an ObservationMetaDataGenerator and still get ObservationMetaData
+        out
+        """
+
+        pointing_list = self.gen.getOpSimRecords(fieldRA=numpy.degrees(1.370916))
+        self.assertGreater(len(pointing_list), 1)
+        local_gen = ObservationMetaDataGenerator()
+        obs_list = local_gen.ObservationMetaDataFromPointingArray(pointing_list)
+        self.assertEqual(len(obs_list), len(pointing_list))
+
+        for pp in pointing_list:
+            obs = local_gen.ObservationMetaDataFromPointing(pp)
+
     def testQueryLimit(self):
         """
         Test that, when we specify a limit on the number of ObservationMetaData we want returned,

--- a/tests/testObservationMetaDataGenerator.py
+++ b/tests/testObservationMetaDataGenerator.py
@@ -230,6 +230,41 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
             for obs in results:
                 self.assertEqual(get_val_from_obs(tag, obs), bounds[ii][1], msg=msg)
 
+    def testOpSimQueryExact(self):
+        """
+        Test that querying OpSim records for exact values works
+        """
+
+        bounds = [
+        ('obsHistID',5973),
+        ('expDate',1220779),
+        ('fieldRA',numpy.degrees(1.370916)),
+        ('fieldDec',numpy.degrees(-0.456238)),
+        ('moonRA',numpy.degrees(2.914132)),
+        ('moonDec',numpy.degrees(0.06305)),
+        ('rotSkyPos',numpy.degrees(3.116656)),
+        ('telescopeFilter','i'),
+        ('rawSeeing',0.728562),
+        ('seeing', 0.88911899999999999),
+        ('sunAlt',numpy.degrees(-0.522905)),
+        ('moonAlt',numpy.degrees(0.099096)),
+        ('dist2Moon',numpy.degrees(1.570307)),
+        ('moonPhase',52.2325),
+        ('expMJD',49367.129396),
+        ('visitExpTime',30.0),
+        ('m5',22.815249),
+        ('skyBrightness',19.017605)]
+
+
+        for line in bounds:
+            tag = line[0]
+            args = {tag: line[1]}
+            results = self.gen.getOpSimRecords(**args)
+            msg = 'failed while querying %s' % tag
+            self.assertGreater(len(results), 0, msg=msg)
+            for rec in results:
+                self.assertEqual(get_val_from_rec(tag, rec), line[1], msg=msg)
+
     def testQueryLimit(self):
         """
         Test that, when we specify a limit on the number of ObservationMetaData we want returned,

--- a/tests/testPhoSimCatalogs.py
+++ b/tests/testPhoSimCatalogs.py
@@ -2,18 +2,15 @@ from __future__ import with_statement
 import os
 import unittest
 import lsst.utils.tests as utilsTests
-import sqlite3
-import numpy
-import json
 import lsst.utils
-from collections import OrderedDict
 from lsst.sims.utils import defaultSpecMap, altAzPaFromRaDec
-from lsst.sims.catalogs.measures.instance import compound, CompoundInstanceCatalog
-from lsst.sims.catUtils.utils import testStarsDBObj, testGalaxyDiskDBObj, \
-                                     testGalaxyBulgeDBObj, testGalaxyAgnDBObj
-from lsst.sims.catUtils.exampleCatalogDefinitions import PhoSimCatalogSersic2D, PhoSimCatalogPoint, \
-                                                         PhoSimCatalogZPoint
+from lsst.sims.catalogs.measures.instance import CompoundInstanceCatalog
+from lsst.sims.catUtils.utils import (testStarsDBObj, testGalaxyDiskDBObj,
+                                      testGalaxyBulgeDBObj, testGalaxyAgnDBObj)
+from lsst.sims.catUtils.exampleCatalogDefinitions import (PhoSimCatalogSersic2D, PhoSimCatalogPoint,
+                                                          PhoSimCatalogZPoint)
 from lsst.sims.catalogs.generation.utils import makePhoSimTestDB
+
 
 class PhoSimCatalogTest(unittest.TestCase):
 
@@ -23,28 +20,28 @@ class PhoSimCatalogTest(unittest.TestCase):
         self.diskDB = testGalaxyDiskDBObj(driver='sqlite', database='PhoSimTestDatabase.db')
         self.agnDB = testGalaxyAgnDBObj(driver='sqlite', database='PhoSimTestDatabase.db')
         self.starDB = testStarsDBObj(driver='sqlite', database='PhoSimTestDatabase.db')
-        filter_translation={'u':0,'g':1, 'r':2, 'i':3, 'z':4, 'y':5}
-        alt, az, pa = altAzPaFromRaDec(self.obs_metadata.pointingRA, self.obs_metadata.pointingDec, self.obs_metadata)
+        filter_translation = {'u': 0, 'g': 1, 'r': 2, 'i': 3, 'z': 4, 'y': 5}
+        alt, az, pa = altAzPaFromRaDec(self.obs_metadata.pointingRA,
+                                       self.obs_metadata.pointingDec,
+                                       self.obs_metadata)
         self.control_header = ['Opsim_moondec %.9g\n' % self.obs_metadata.phoSimMetaData['Opsim_moondec'],
-                              'Opsim_rottelpos %.9g\n' % self.obs_metadata.phoSimMetaData['Opsim_rottelpos'],
-                              'Unrefracted_Dec %.9g\n' % self.obs_metadata.pointingDec,
-                              'Opsim_moonalt %.9g\n' % self.obs_metadata.phoSimMetaData['Opsim_moonalt'],
-                              'Opsim_rotskypos %.9g\n' % self.obs_metadata.rotSkyPos,
-                              'Opsim_moonra %.9g\n' % self.obs_metadata.phoSimMetaData['Opsim_moonra'],
-                              'Opsim_sunalt %.9g\n' % self.obs_metadata.phoSimMetaData['Opsim_sunalt'],
-                              'Opsim_expmjd %.9g\n' % self.obs_metadata.mjd.TAI,
-                              'Opsim_azimuth %.9g\n' % az,
-                              'Unrefracted_RA %.9g\n' % self.obs_metadata.pointingRA,
-                              'Opsim_dist2moon %.9g\n' % self.obs_metadata.phoSimMetaData['Opsim_dist2moon'],
-                              'Opsim_filter %d\n' % filter_translation[self.obs_metadata.bandpass],
-                              'Opsim_altitude %.9g\n' % alt]
-
+                               'Opsim_rottelpos %.9g\n' % self.obs_metadata.phoSimMetaData['Opsim_rottelpos'],
+                               'Unrefracted_Dec %.9g\n' % self.obs_metadata.pointingDec,
+                               'Opsim_moonalt %.9g\n' % self.obs_metadata.phoSimMetaData['Opsim_moonalt'],
+                               'Opsim_rotskypos %.9g\n' % self.obs_metadata.rotSkyPos,
+                               'Opsim_moonra %.9g\n' % self.obs_metadata.phoSimMetaData['Opsim_moonra'],
+                               'Opsim_sunalt %.9g\n' % self.obs_metadata.phoSimMetaData['Opsim_sunalt'],
+                               'Opsim_expmjd %.9g\n' % self.obs_metadata.mjd.TAI,
+                               'Opsim_azimuth %.9g\n' % az,
+                               'Unrefracted_RA %.9g\n' % self.obs_metadata.pointingRA,
+                               'Opsim_dist2moon %.9g\n' % self.obs_metadata.phoSimMetaData['Opsim_dist2moon'],
+                               'Opsim_filter %d\n' % filter_translation[self.obs_metadata.bandpass],
+                               'Opsim_altitude %.9g\n' % alt]
 
     def tearDown(self):
 
         if os.path.exists('PhoSimTestDatabase.db'):
             os.unlink('PhoSimTestDatabase.db')
-
 
     def verify_catalog(self, file_name):
         """
@@ -56,7 +53,6 @@ class PhoSimCatalogTest(unittest.TestCase):
                 self.assertIn(control_line, lines)
 
             self.assertGreater(len(lines), len(self.control_header)+3)
-
 
     def testSpecFileMap(self):
         """
@@ -73,11 +69,10 @@ class PhoSimCatalogTest(unittest.TestCase):
 
         # verify that the usual stellar mappings still apply
         for test_name in ('kp_123.txt', 'km_123.txt', 'Const_123.txt', 'Exp_123.txt', 'Burst_123.txt',
-                         'bergeron_123.txt', 'burrows_123.txt', 'm1_123.txt', 'L1_123.txt', 'l1_123.txt',
-                         'Inst_123.txt'):
+                          'bergeron_123.txt', 'burrows_123.txt', 'm1_123.txt', 'L1_123.txt', 'l1_123.txt',
+                          'Inst_123.txt'):
 
             self.assertEqual(cat.specFileMap[test_name], defaultSpecMap[test_name])
-
 
     def testCatalog(self):
         """
@@ -90,7 +85,7 @@ class PhoSimCatalogTest(unittest.TestCase):
         testStar = PhoSimCatalogPoint(self.starDB, obs_metadata = self.obs_metadata)
 
         catName = os.path.join(lsst.utils.getPackageDir('sims_catUtils'),
-                               'tests','scratchSpace','phoSimTestCatalog.txt')
+                               'tests', 'scratchSpace', 'phoSimTestCatalog.txt')
 
         testBulge.write_catalog(catName)
         testDisk.write_catalog(catName, write_header=False, write_mode='a')
@@ -102,7 +97,6 @@ class PhoSimCatalogTest(unittest.TestCase):
         if os.path.exists(catName):
             os.unlink(catName)
 
-
     def testCompoundCatalog(self):
         """
         This test writes a PhoSim input catalog and compares it, one line at a time
@@ -113,7 +107,7 @@ class PhoSimCatalogTest(unittest.TestCase):
 
         # first, generate the catalog without a CompoundInstanceCatalog
         single_catName = os.path.join(lsst.utils.getPackageDir('sims_catUtils'),
-                                      'tests','scratchSpace','phoSimTestCatalog_single.txt')
+                                      'tests', 'scratchSpace', 'phoSimTestCatalog_single.txt')
 
         testBulge = PhoSimCatalogSersic2D(self.bulgeDB, obs_metadata = self.obs_metadata)
         testDisk = PhoSimCatalogSersic2D(self.diskDB, obs_metadata = self.obs_metadata)
@@ -139,7 +133,7 @@ class PhoSimCatalogTest(unittest.TestCase):
         class dummyBulgeDB(dummyDBbase, testGalaxyBulgeDBObj):
             objid = 'dummy_bulge'
 
-        class dummyDiskDB(dummyDBbase,  testGalaxyDiskDBObj):
+        class dummyDiskDB(dummyDBbase, testGalaxyDiskDBObj):
             objid = 'dummy_disk'
 
         class dummyAgnDB(dummyDBbase, testGalaxyAgnDBObj):
@@ -147,7 +141,6 @@ class PhoSimCatalogTest(unittest.TestCase):
 
         class dummyStarDB(dummyDBbase, testStarsDBObj):
             objid = 'dummy_stars'
-
 
         compoundCatalog = CompoundInstanceCatalog([PhoSimCatalogSersic2D, PhoSimCatalogSersic2D,
                                                    PhoSimCatalogZPoint, PhoSimCatalogPoint],
@@ -176,7 +169,6 @@ class PhoSimCatalogTest(unittest.TestCase):
                 for line in compound_lines:
                     self.assertIn(line, single_lines)
 
-
         if os.path.exists(compound_catName):
             os.unlink(compound_catName)
 
@@ -191,7 +183,10 @@ def suite():
 
     return unittest.TestSuite(suites)
 
+
 def run(shouldExit = False):
     utilsTests.run(suite(), shouldExit)
+
+
 if __name__ == "__main__":
     run(True)

--- a/tests/testPhoSimCatalogs.py
+++ b/tests/testPhoSimCatalogs.py
@@ -7,7 +7,7 @@ import numpy
 import json
 import lsst.utils
 from collections import OrderedDict
-from lsst.sims.utils import defaultSpecMap
+from lsst.sims.utils import defaultSpecMap, altAzPaFromRaDec
 from lsst.sims.catalogs.measures.instance import compound, CompoundInstanceCatalog
 from lsst.sims.catUtils.utils import testStarsDBObj, testGalaxyDiskDBObj, \
                                      testGalaxyBulgeDBObj, testGalaxyAgnDBObj
@@ -24,19 +24,20 @@ class PhoSimCatalogTest(unittest.TestCase):
         self.agnDB = testGalaxyAgnDBObj(driver='sqlite', database='PhoSimTestDatabase.db')
         self.starDB = testStarsDBObj(driver='sqlite', database='PhoSimTestDatabase.db')
         filter_translation={'u':0,'g':1, 'r':2, 'i':3, 'z':4, 'y':5}
-        self.control_header = ['Opsim_moondec %.9g\n' % numpy.degrees(self.obs_metadata.phoSimMetaData['Opsim_moondec'][0]),
-                              'Opsim_rottelpos %.9g\n' % numpy.degrees(self.obs_metadata.phoSimMetaData['Opsim_rottelpos'][0]),
-                              'Unrefracted_Dec %.9g\n' % numpy.degrees(self.obs_metadata.phoSimMetaData['pointingDec'][0]),
-                              'Opsim_moonalt %.9g\n' % numpy.degrees(self.obs_metadata.phoSimMetaData['Opsim_moonalt'][0]),
-                              'Opsim_rotskypos %.9g\n' % numpy.degrees(self.obs_metadata.phoSimMetaData['Opsim_rotskypos'][0]),
-                              'Opsim_moonra %.9g\n' % numpy.degrees(self.obs_metadata.phoSimMetaData['Opsim_moonra'][0]),
-                              'Opsim_sunalt %.9g\n' % numpy.degrees(self.obs_metadata.phoSimMetaData['Opsim_sunalt'][0]),
-                              'Opsim_expmjd %.9g\n' % self.obs_metadata.phoSimMetaData['Opsim_expmjd'][0],
-                              'Unrefracted_Azimuth %.9g\n' % numpy.degrees(self.obs_metadata.phoSimMetaData['Unrefracted_Azimuth'][0]),
-                              'Unrefracted_RA %.9g\n' % numpy.degrees(self.obs_metadata.phoSimMetaData['pointingRA'][0]),
-                              'Opsim_dist2moon %.9g\n' % numpy.degrees(self.obs_metadata.phoSimMetaData['Opsim_dist2moon'][0]),
-                              'Opsim_filter %d\n' % filter_translation[self.obs_metadata.phoSimMetaData['Opsim_filter'][0]],
-                              'Unrefracted_Altitude %.9g\n' % numpy.degrees(self.obs_metadata.phoSimMetaData['Unrefracted_Altitude'][0])]
+        alt, az, pa = altAzPaFromRaDec(self.obs_metadata.pointingRA, self.obs_metadata.pointingDec, self.obs_metadata)
+        self.control_header = ['Opsim_moondec %.9g\n' % self.obs_metadata.phoSimMetaData['Opsim_moondec'],
+                              'Opsim_rottelpos %.9g\n' % self.obs_metadata.phoSimMetaData['Opsim_rottelpos'],
+                              'Unrefracted_Dec %.9g\n' % self.obs_metadata.pointingDec,
+                              'Opsim_moonalt %.9g\n' % self.obs_metadata.phoSimMetaData['Opsim_moonalt'],
+                              'Opsim_rotskypos %.9g\n' % self.obs_metadata.rotSkyPos,
+                              'Opsim_moonra %.9g\n' % self.obs_metadata.phoSimMetaData['Opsim_moonra'],
+                              'Opsim_sunalt %.9g\n' % self.obs_metadata.phoSimMetaData['Opsim_sunalt'],
+                              'Opsim_expmjd %.9g\n' % self.obs_metadata.mjd.TAI,
+                              'Opsim_azimuth %.9g\n' % az,
+                              'Unrefracted_RA %.9g\n' % self.obs_metadata.pointingRA,
+                              'Opsim_dist2moon %.9g\n' % self.obs_metadata.phoSimMetaData['Opsim_dist2moon'],
+                              'Opsim_filter %d\n' % filter_translation[self.obs_metadata.bandpass],
+                              'Opsim_altitude %.9g\n' % alt]
 
 
     def tearDown(self):

--- a/tests/testSSM_Diasources.py
+++ b/tests/testSSM_Diasources.py
@@ -2,7 +2,6 @@ from __future__ import with_statement
 import os, sys
 import traceback
 import unittest
-from copy import deepcopy
 import lsst.utils.tests as utilsTests
 
 import numpy as np
@@ -14,15 +13,18 @@ from lsst.utils import getPackageDir
 # photometric parameters (exptime lives here for dmag calculation)
 from lsst.sims.photUtils import PhotometricParameters
 # SSM catalog modules
-from lsst.sims.catUtils.baseCatalogModels import SolarSystemObj, CometObj, MBAObj, NEOObj, MiscSolarSystemObj
+from lsst.sims.catUtils.baseCatalogModels import SolarSystemObj
 from lsst.sims.catUtils.mixins import PhotometrySSM, AstrometrySSM, CameraCoords, ObsMetadataBase
 from lsst.sims.catalogs.measures.instance import InstanceCatalog
 # For camera.
 from lsst.obs.lsstSim import LsstSimMapper
 
 import time
+
+
 def dtime(time_prev):
     return (time.time() - time_prev, time.time())
+
 
 def failedOnFatboy(tracebackList):
     """
@@ -42,7 +44,7 @@ def failedOnFatboy(tracebackList):
         if 'sims' in item[0]:
             lastSimsDex = ix
 
-    if lastSimsDex<0:
+    if lastSimsDex < 0:
         return False
 
     if '_connect_to_engine' in tracebackList[lastSimsDex][2]:
@@ -56,15 +58,18 @@ def reassure():
     print 'Sometimes that happens.  Do not worry.'
 
 # Build sso instance class
-basic_columns = ['objid', 'expMJD', 'raJ2000', 'decJ2000', 'velRa', 'velDec', 'skyVelocity', 'dist', 'dmagTrailing', 'dmagDetection',
-                 'sedFilename', 'magFilter', 'magSNR', 'visibility', 'seeing', 'bandpass', 'visitExpTime', 'm5']
+basic_columns = ['objid', 'expMJD', 'raJ2000', 'decJ2000', 'velRa', 'velDec',
+                 'skyVelocity', 'dist', 'dmagTrailing', 'dmagDetection',
+                 'sedFilename', 'magFilter', 'magSNR', 'visibility',
+                 'seeing', 'bandpass', 'visitExpTime', 'm5']
+
 
 class ssmCat(InstanceCatalog, PhotometrySSM, AstrometrySSM, ObsMetadataBase, CameraCoords):
     column_outputs = basic_columns
     cannot_be_null = ['visibility']
     transformations = {'raJ2000': np.degrees, 'decJ2000': np.degrees,
                        'velRa': np.degrees, 'velDec': np.degrees}
-    default_formats = {'f':'%.13f'}
+    default_formats = {'f': '%.13f'}
 
 
 class ssmCatCamera(ssmCat):
@@ -73,7 +78,7 @@ class ssmCatCamera(ssmCat):
     cannot_be_null = ['visibility', 'chipName']
     transformations = {'raJ2000': np.degrees, 'decJ2000': np.degrees,
                        'velRa': np.degrees, 'velDec': np.degrees}
-    default_formats = {'f':'%.13f'}
+    default_formats = {'f': '%.13f'}
 
 ######
 
@@ -89,15 +94,16 @@ class createSSMSourceCatalogsTest(unittest.TestCase):
         generator = ObservationMetaDataGenerator(database=database, driver='sqlite')
 
         night = 20
-        query = 'select min(expMJD), max(expMJD) from summary where night=%d' %(night)
+        query = 'select min(expMJD), max(expMJD) from summary where night=%d' % (night)
         res = generator.opsimdb.execute_arbitrary(query)
         expMJD_min = res[0][0]
         expMJD_max = res[0][1]
 
-        obsMetaDataResults = generator.getObservationMetaData(expMJD=(expMJD_min, expMJD_max), limit=3, boundLength=2.2)
+        obsMetaDataResults = generator.getObservationMetaData(expMJD=(expMJD_min, expMJD_max),
+                                                              limit=3, boundLength=2.2)
 
         dt, t = dtime(t)
-        print 'To query opsim database: %f seconds' %(dt)
+        print 'To query opsim database: %f seconds' % (dt)
 
         write_header = True
         write_mode = 'w'
@@ -110,21 +116,27 @@ class createSSMSourceCatalogsTest(unittest.TestCase):
                 os.unlink(output_cat)
 
             for obsMeta in obsMetaDataResults:
-                # But moving objects databases are not currently complete for all years. Push forward to night=747.
+                # But moving objects databases are not currently complete for all years.
+                # Push forward to night=747.
                 # (note that we need the phosim dictionary as well)
                 newMJD = obsMeta.mjd.TAI + (747 - 20)
                 phoSimMetaDict = {'exptime': [30]}
                 obs = ObservationMetaData(mjd=newMJD,
-                                          pointingRA=obsMeta.pointingRA, pointingDec=obsMeta.pointingDec,
-                                          bandpassName=obsMeta.bandpass, rotSkyPos=obsMeta.rotSkyPos,
-                                          m5=obsMeta.m5[obsMeta.bandpass], seeing=obsMeta.seeing[obsMeta.bandpass],
-                                          boundLength=obsMeta.boundLength, boundType=obsMeta.boundType)
+                                          pointingRA=obsMeta.pointingRA,
+                                          pointingDec=obsMeta.pointingDec,
+                                          bandpassName=obsMeta.bandpass,
+                                          rotSkyPos=obsMeta.rotSkyPos,
+                                          m5=obsMeta.m5[obsMeta.bandpass],
+                                          seeing=obsMeta.seeing[obsMeta.bandpass],
+                                          boundLength=obsMeta.boundLength,
+                                          boundType=obsMeta.boundType)
 
                 obs.phoSimMetaData = phoSimMetaDict
 
                 mySsmDb = ssmCatCamera(ssmObj, obs_metadata = obs)
                 #mySsmDb = ssmCat(ssmObj, obs_metadata = obs)
-                photParams = PhotometricParameters(exptime = obs.phoSimMetaData['exptime'][0], nexp=1, bandpass=obs.bandpass)
+                photParams = PhotometricParameters(exptime = obs.phoSimMetaData['exptime'][0],
+                                                   nexp=1, bandpass=obs.bandpass)
                 mySsmDb.photParams = photParams
 
                 try:
@@ -150,7 +162,7 @@ class createSSMSourceCatalogsTest(unittest.TestCase):
                 write_header = False
 
                 dt, t = dtime(t)
-                print 'To query solar system objects: %f seconds (obs MJD time %f)' %(dt, obs.mjd.TAI)
+                print 'To query solar system objects: %f seconds (obs MJD time %f)' % (dt, obs.mjd.TAI)
 
                 if os.path.exists(output_cat):
                     os.unlink(output_cat)
@@ -177,7 +189,10 @@ def suite():
     suites += unittest.makeSuite(createSSMSourceCatalogsTest)
     return unittest.TestSuite(suites)
 
+
 def run(shouldExit = False):
     utilsTests.run(suite(), shouldExit)
+
+
 if __name__ == "__main__":
     run(True)

--- a/tests/testSSM_Diasources.py
+++ b/tests/testSSM_Diasources.py
@@ -81,6 +81,8 @@ class createSSMSourceCatalogsTest(unittest.TestCase):
 
     def test_ssm_catalog_creation(self):
 
+        output_cat = os.path.join(getPackageDir('sims_catUtils'), 'tests', 'scratchSpace', 'catsim_ssm_test')
+
         t = time.time()
         # Fake opsim data.
         database = os.path.join(getPackageDir('SIMS_DATA'), 'OpSimData/opsimblitz1_1133_sqlite.db')
@@ -104,7 +106,6 @@ class createSSMSourceCatalogsTest(unittest.TestCase):
             #ssmObj = NEOObj()
             ssmObj = SolarSystemObj()
 
-            output_cat = os.path.join(getPackageDir('sims_catUtils'), 'tests', 'scratchSpace', 'catsim_ssm_test')
             if os.path.exists(output_cat):
                 os.unlink(output_cat)
 
@@ -165,6 +166,9 @@ class createSSMSourceCatalogsTest(unittest.TestCase):
                 pass
             else:
                 raise
+
+        if os.path.exists(output_cat):
+            os.unlink(output_cat)
 
 
 def suite():

--- a/tests/testSSM_Diasources.py
+++ b/tests/testSSM_Diasources.py
@@ -113,11 +113,14 @@ class createSSMSourceCatalogsTest(unittest.TestCase):
                 # (note that we need the phosim dictionary as well)
                 newMJD = obsMeta.mjd.TAI + (747 - 20)
                 phoSimMetaDict = {'exptime': [30]}
-                obs = ObservationMetaData(phoSimMetaData = phoSimMetaDict, mjd=newMJD,
+                obs = ObservationMetaData(mjd=newMJD,
                                           pointingRA=obsMeta.pointingRA, pointingDec=obsMeta.pointingDec,
                                           bandpassName=obsMeta.bandpass, rotSkyPos=obsMeta.rotSkyPos,
                                           m5=obsMeta.m5[obsMeta.bandpass], seeing=obsMeta.seeing[obsMeta.bandpass],
                                           boundLength=obsMeta.boundLength, boundType=obsMeta.boundType)
+
+                obs.phoSimMetaData = phoSimMetaDict
+
                 mySsmDb = ssmCatCamera(ssmObj, obs_metadata = obs)
                 #mySsmDb = ssmCat(ssmObj, obs_metadata = obs)
                 photParams = PhotometricParameters(exptime = obs.phoSimMetaData['exptime'][0], nexp=1, bandpass=obs.bandpass)


### PR DESCRIPTION
This pull request re-factors the way we handle PhoSim header information in ObservationMetaData.  Instead of taking all of the header information from ObservationMetaData.phoSimMetaData, pointing information, date, rotSkyPos, and bandpass are taken from the appropriate ObservationMetaData member variables.  phoSimMetaData only exists to store additional information that may have come from an Opsim pointing (or from user input).

A method write_phoSim_header() is added to the PhoSim InstanceCatalog classes in sims_catUtils to parse this new API.

ObservationMetaDataGenerator.py is also updated.

There are pull requests in

sims_utils
sims_catalogs_generation
sims_catUtils
sims_GalSimInterface