### PR TITLE
Feature/sim 2108/limited light curves

### DIFF
--- a/python/lsst/sims/catUtils/mixins/PhotometryMixin.py
+++ b/python/lsst/sims/catUtils/mixins/PhotometryMixin.py
@@ -487,15 +487,6 @@ class PhotometryGalaxies(PhotometryBase):
         if not hasattr(self, 'lsstBandpassDict'):
             self.lsstBandpassDict = BandpassDict.loadTotalBandpassesFromFiles()
 
-        # totally optional; list the indices in self.lsstBandpassDict
-        # of the columns which will actually be output (so that we don't
-        # spend time calculating things we do not need)
-        indices = [ii for ii, name in enumerate(self.get_lsst_bulge_mags._colnames) \
-                   if name in self._actually_calculated_columns]
-
-        if len(indices)==6:
-            indices = None
-
         # actually calculate the magnitudes
         return self._magnitudeGetter('bulge', self.lsstBandpassDict,
                                      self.get_lsst_bulge_mags._colnames)
@@ -512,15 +503,6 @@ class PhotometryGalaxies(PhotometryBase):
         if not hasattr(self, 'lsstBandpassDict'):
             self.lsstBandpassDict = BandpassDict.loadTotalBandpassesFromFiles()
 
-        # totally optional; list the indices in self.lsstBandpassDict
-        # of the columns which will actually be output (so that we don't
-        # spend time calculating things we do not need)
-        indices = [ii for ii, name in enumerate(self.get_lsst_disk_mags._colnames) \
-                   if name in self._actually_calculated_columns]
-
-        if len(indices)==6:
-            indices = None
-
         # actually calculate the magnitudes
         return self._magnitudeGetter('disk', self.lsstBandpassDict,
                                      self.get_lsst_disk_mags._colnames)
@@ -535,15 +517,6 @@ class PhotometryGalaxies(PhotometryBase):
         # load a BandpassDict of LSST bandpasses, if not done already
         if not hasattr(self, 'lsstBandpassDict'):
             self.lsstBandpassDict = BandpassDict.loadTotalBandpassesFromFiles()
-
-        # totally optional; list the indices in self.lsstBandpassDict
-        # of the columns which will actually be output (so that we don't
-        # spend time calculating things we do not need)
-        indices = [ii for ii, name in enumerate(self.get_lsst_agn_mags._colnames) \
-                   if name in self._actually_calculated_columns]
-
-        if len(indices)==6:
-            indices = None
 
         # actually calculate the magnitudes
         return self._magnitudeGetter('agn', self.lsstBandpassDict,
@@ -612,7 +585,7 @@ class PhotometryStars(PhotometryBase):
                                           galacticAvList=galacticAvList)
 
 
-    def _magnitudeGetter(self, bandpassDict, columnNameList, indices=None):
+    def _magnitudeGetter(self, bandpassDict, columnNameList):
         """
         This method gets the magnitudes for an InstanceCatalog, returning them
         in a 2-D numpy array in which rows correspond to bandpasses and columns

--- a/python/lsst/sims/catUtils/utils/SNIaLightCurveGenerator.py
+++ b/python/lsst/sims/catUtils/utils/SNIaLightCurveGenerator.py
@@ -74,7 +74,7 @@ class SNIaLightCurveGenerator(LightCurveGenerator):
     class _filterCatalogClass(_sniaLightCurveCatalog):
         column_outputs = ["uniqueId", "t0"]
 
-    def _light_curves_from_query(self, cat_dict, query_result, grp):
+    def _light_curves_from_query(self, cat_dict, query_result, grp, lc_per_field=None):
 
         t_dict = {}
         gamma_dict = {}

--- a/tests/testSN.py
+++ b/tests/testSN.py
@@ -773,6 +773,7 @@ class SNIaLightCurveTest(unittest.TestCase):
         control_lc, truth = gen.light_curves_from_pointings(pointings)
         test_lc, truth = gen.light_curves_from_pointings(pointings, lc_per_field=lc_limit)
         self.assertGreater(len(control_lc), len(test_lc))
+        self.assertLessEqual(len(test_lc), lc_limit*len(pointings))
 
 
 class MemoryTestClass(lsst.utils.tests.MemoryTestCase):


### PR DESCRIPTION
Modify the LightCurveGenerator so that you can limit the number of light curves drawn form objects based on the GalaxyTileObj CatalogDBObject.