### PR TITLE
U/danielsf/observation meta data generator on night

### DIFF
--- a/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
+++ b/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
@@ -404,12 +404,12 @@ class ObservationMetaDataGenerator(object):
         be returned
 
         @param [in] boundType is the boundType of the ObservationMetaData to be returned
-        (see documentation in sims_catalogs_generation/../db/spatialBounds.py for more
-        details)
 
         @param [in] boundLength is the boundLength of the ObservationMetaData to be
-        returned (in degrees; see documentation in
-        sims_catalogs_generation/../db/spatialBounds.py for more details)
+        returned
+
+        See the docstring for ObservationMetaData for a clearer explanation of
+        boundType and boundLength.
 
         All other input parameters are constraints to be placed on the SQL query of the
         opsim output db.  These contraints can either be tuples of the form (min, max)

--- a/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
+++ b/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
@@ -160,6 +160,22 @@ class ObservationMetaDataGenerator(object):
 
         self.dtype = np.dtype(dtypeList)
 
+    def getOpsimRecordsFromQuery(self, query):
+        """
+        Perform an arbitrary SQL query on the Opsim database Summary table.
+        Return the results as a numpy recarray.
+
+        Parameters
+        ----------
+        A string containing the SQL query to be executed
+
+        Returns
+        -------
+        `numpy.recarray` with OpSim records. The column names may be obtained as
+        res.dtype.names
+        """
+        return self.opsimdb.execute_arbitrary(query, dtype=self.dtype)
+
     def getOpSimRecords(self, obsHistID=None, expDate=None, night=None, fieldRA=None,
                         fieldDec=None, moonRA=None, moonDec=None,
                         rotSkyPos=None, telescopeFilter=None, rawSeeing=None,
@@ -269,8 +285,7 @@ class ObservationMetaDataGenerator(object):
             raise RuntimeError('You did not specify any contraints on your query;' +
                                ' you will just return ObservationMetaData for all poitnings')
 
-        results = self.opsimdb.execute_arbitrary(query, dtype=self.dtype)
-        return results
+        return self.getOpsimRecordsFromQuery(query)
 
     def ObservationMetaDataFromPointing(self, OpSimPointingRecord, OpSimColumns=None,
                                         boundLength=1.75, boundType='circle'):

--- a/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
+++ b/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
@@ -248,7 +248,7 @@ class ObservationMetaDataGenerator(object):
                         vmin = value[0]
                         vmax = value[1]
 
-                    query += ' %s > %s AND %s < %s' % \
+                    query += ' %s >= %s AND %s <= %s' % \
                              (transform[0], vmin, transform[0], vmax)
                 else:
                     # perform any necessary coordinate transformations

--- a/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
+++ b/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
@@ -160,7 +160,7 @@ class ObservationMetaDataGenerator(object):
 
         self.dtype = np.dtype(dtypeList)
 
-    def getOpSimRecords(self, obsHistID=None, expDate=None, fieldRA=None,
+    def getOpSimRecords(self, obsHistID=None, expDate=None, night=None, fieldRA=None,
                         fieldDec=None, moonRA=None, moonDec=None,
                         rotSkyPos=None, telescopeFilter=None, rawSeeing=None,
                         seeing=None, sunAlt=None, moonAlt=None, dist2Moon=None,
@@ -176,7 +176,7 @@ class ObservationMetaDataGenerator(object):
 
         Parameters
         ----------
-        obsHistID, expDate, fieldRA, fieldDec, moonRa, moonDec, rotSkyPos,
+        obsHistID, expDate, night, fieldRA, fieldDec, moonRa, moonDec, rotSkyPos,
         telescopeFilter, rawSeeing, seeing, sunAlt, moonAlt, dist2Moon,
         moonPhase, expMJD, altitude, azimuth, visitExpTime, airmass,
         skyBrightness, m5 : tuples of length 2, optional, defaults to None
@@ -373,7 +373,7 @@ class ObservationMetaDataGenerator(object):
 
         return out
 
-    def getObservationMetaData(self, obsHistID=None, expDate=None, fieldRA=None, fieldDec=None,
+    def getObservationMetaData(self, obsHistID=None, expDate=None, night=None, fieldRA=None, fieldDec=None,
                                moonRA=None, moonDec=None, rotSkyPos=None, telescopeFilter=None,
                                rawSeeing=None, seeing=None, sunAlt=None, moonAlt=None, dist2Moon=None,
                                moonPhase=None, expMJD=None, altitude=None, azimuth=None,
@@ -426,12 +426,14 @@ class ObservationMetaDataGenerator(object):
         @param [in] obsHistID the integer used by OpSim to label pointings
         @param [in] expDate is the date of the exposure (units????)
         @param [in] expMJD is the MJD of the exposure
+        @param [in] night is the night (an int starting at zero) on which the observation took place
         @param [in] m5 is the five sigma depth of the observation
         @param [in] skyBrightness
         """
 
         OpSimPointingRecords = self.getOpSimRecords(obsHistID=obsHistID,
                                                     expDate=expDate,
+                                                    night=night,
                                                     fieldRA=fieldRA,
                                                     fieldDec=fieldDec,
                                                     moonRA=moonRA,

--- a/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
+++ b/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
@@ -175,7 +175,7 @@ class ObservationMetaDataGenerator(object):
         res.dtype.names
         """
 
-        query = self.baseQuery + ' FROM SUMMARY'
+        query = self.baseQuery + ' FROM SUMMARY '
 
         query += constraint
 
@@ -253,7 +253,7 @@ class ObservationMetaDataGenerator(object):
                 if nConstraints > 0:
                     constraint += ' AND'
                 else:
-                    constraint += ' WHERE '
+                    constraint += 'WHERE '
 
                 if isinstance(value, tuple):
                     if len(value) > 2:
@@ -481,3 +481,29 @@ class ObservationMetaDataGenerator(object):
                                                            boundType=boundType,
                                                            boundLength=boundLength)
         return output
+
+    def getObservationMetaDataFromConstraint(self, constraint, boundType='circle', boundLength=1.75):
+        """
+        Get a list of ObservationMetaData corresponding to an arbitrary SQL query
+
+        Parameters
+        ----------
+        query: A string encoding the 'where' clause for an SQL query to be executed
+
+        boundType: The shape of the field of view returned in the ObservationMetaData
+
+        boundLength: The characteristic length (in degrees) of the field of view returned
+                     in the ObservationMetaData
+
+        See the docstring for ObservationMetaData for a clearer explanation of
+        boundType and boundLength.
+
+        Returns
+        -------
+        A list of the ObservationMetaData returned by that query
+        """
+        OpSimPointingRecords = self.getOpsimRecordsFromConstraint(constraint)
+        return self.ObservationMetaDataFromPointingArray(OpSimPointingRecords,
+                                                         OpSimColumns=None,
+                                                         boundType=boundType,
+                                                         boundLength=boundLength)

--- a/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
+++ b/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
@@ -281,7 +281,7 @@ class ObservationMetaDataGenerator(object):
 
                 nConstraints += 1
 
-        constraint += ' GROUP BY expMJD'
+        constraint += ' GROUP BY expMJD ORDER BY expMJD'
 
         if limit is not None:
             constraint += ' LIMIT %d' % limit

--- a/tests/testObservationMetaDataGenerator.py
+++ b/tests/testObservationMetaDataGenerator.py
@@ -420,9 +420,28 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
         # make sure we get at least 600
 
         for obs in results:
-            self.assertEqual(obs._OpsimMetaData['night'], 15)
+            self.assertEqual(obs.OpsimMetaData['night'], 15)
             self.assertGreaterEqual(obs.mjd.TAI, night0+14.9)
             self.assertLessEqual(obs.mjd.TAI, night0+15.9)
+
+    def testQueryOnConstraint(self):
+        """
+        Test that we can create a list of ObservationMetaData with an
+        arbitary SQL 'where' clause
+        """
+
+        constraint = 'where night<3 and altitude>1.3'
+        results = self.gen.getObservationMetaDataFromConstraint(constraint)
+        self.assertGreater(len(results), 0)
+        for obs in results:
+            self.assertLess(obs.OpsimMetaData['night'], 3)
+            self.assertGreater(obs.OpsimMetaData['altitude'], 1.3)
+
+        constraint = 'where altitude<1.2 limit 10'
+        results = self.gen.getObservationMetaDataFromConstraint(constraint)
+        self.assertEqual(len(results), 10)
+        for obs in results:
+            self.assertLess(obs.OpsimMetaData['altitude'], 1.2)
 
     def testCreationOfPhoSimCatalog(self):
         """

--- a/tests/testObservationMetaDataGenerator.py
+++ b/tests/testObservationMetaDataGenerator.py
@@ -142,8 +142,8 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
 
             for obs in results:
                 val = get_val_from_obs(tag, obs)
-                self.assertGreater(val, line[1][0], msg=msg)
-                self.assertLess(val, line[1][1], msg=msg)
+                self.assertGreaterEqual(val, line[1][0], msg=msg)
+                self.assertLessEqual(val, line[1][1], msg=msg)
 
         # test querying on two columns at once
         for ix in range(len(bounds)):
@@ -161,10 +161,10 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
                 for obs in results:
                     v1 = get_val_from_obs(tag1, obs)
                     v2 = get_val_from_obs(tag2, obs)
-                    self.assertGreater(v1, bounds[ix][1][0], msg=msg)
-                    self.assertLess(v1, bounds[ix][1][1], msg=msg)
-                    self.assertGreater(v2, bounds[jx][1][0], msg=msg)
-                    self.assertLess(v2, bounds[jx][1][1], msg=msg)
+                    self.assertGreaterEqual(v1, bounds[ix][1][0], msg=msg)
+                    self.assertLessEqual(v1, bounds[ix][1][1], msg=msg)
+                    self.assertGreaterEqual(v2, bounds[jx][1][0], msg=msg)
+                    self.assertLessEqual(v2, bounds[jx][1][1], msg=msg)
 
     def testOpSimQueryOnRanges(self):
         """
@@ -187,8 +187,8 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
             self.assertGreater(len(results), 0)
             for rec in results:
                 val = get_val_from_rec(tag, rec)
-                self.assertGreater(val, line[1][0], msg=msg)
-                self.assertLess(val, line[1][1], msg=msg)
+                self.assertGreaterEqual(val, line[1][0], msg=msg)
+                self.assertLessEqual(val, line[1][1], msg=msg)
 
         for ix in range(len(bounds)):
             tag1 = bounds[ix][0]
@@ -201,10 +201,10 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
                 for rec in results:
                     v1 = get_val_from_rec(tag1, rec)
                     v2 = get_val_from_rec(tag2, rec)
-                    self.assertGreater(v1, bounds[ix][1][0], msg=msg)
-                    self.assertLess(v1, bounds[ix][1][1], msg=msg)
-                    self.assertGreater(v2, bounds[jx][1][0], msg=msg)
-                    self.assertLess(v2, bounds[jx][1][1], msg=msg)
+                    self.assertGreaterEqual(v1, bounds[ix][1][0], msg=msg)
+                    self.assertLessEqual(v1, bounds[ix][1][1], msg=msg)
+                    self.assertGreaterEqual(v2, bounds[jx][1][0], msg=msg)
+                    self.assertLessEqual(v2, bounds[jx][1][1], msg=msg)
 
     def testQueryExactValues(self):
         """
@@ -339,7 +339,7 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
             # adjust the boundLength to accommodate the transformation between
             # ICRS and observed coordinates
             self.assertGreaterEqual(obs_metadata.bounds.radiusdeg, 0.9)
-            self.assertLess(obs_metadata.bounds.radiusdeg, 0.95)
+            self.assertLessEqual(obs_metadata.bounds.radiusdeg, 0.95)
 
             self.assertAlmostEqual(obs_metadata.bounds.RA,
                                    np.radians(obs_metadata.pointingRA), 5)
@@ -396,15 +396,17 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
 
         # the test database goes from night=0 to night=28
         # corresponding to 49353.032079 <= mjd <= 49381.38533
-        night0 = 49353.0
+        night0 = 49353.032079
 
         results = self.gen.getObservationMetaData(night=(11, 13))
         self.assertGreater(len(results), 0)
         for obs in results:
-            self.assertGreater(obs.mjd.TAI, night0+11.0)
-            self.assertLess(obs.mjd.TAI, night0+13.0)
-            self.assertGreater(obs._OpsimMetaData['night'], 11)
-            self.assertLess(obs._OpsimMetaData['night'], 13)
+            self.assertGreaterEqual(obs.mjd.TAI, night0+11.0)
+            self.assertLessEqual(obs.mjd.TAI, night0+13.5)
+            # the 0.5 is there because the last observation on night 13 could be
+            # 13 days and 8 hours after the first observation on night 0
+            self.assertGreaterEqual(obs._OpsimMetaData['night'], 11)
+            self.assertLessEqual(obs._OpsimMetaData['night'], 13)
 
     def testCreationOfPhoSimCatalog(self):
         """
@@ -494,7 +496,7 @@ class ObsMetaDataGenMockOpsimTest(unittest.TestCase):
         self.assertGreater(len(results), 0)
         for obs in results:
             self.assertGreater(obs.pointingRA, raBounds[0])
-            self.assertLess(obs.pointingDec, raBounds[1])
+            self.assertLessEqual(obs.pointingDec, raBounds[1])
 
     def testSelectException(self):
         """

--- a/tests/testObservationMetaDataGenerator.py
+++ b/tests/testObservationMetaDataGenerator.py
@@ -388,6 +388,24 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
             # Make sure that some ObservationMetaData were tested
             self.assertGreater(ct, 0)
 
+    def testQueryOnNight(self):
+        """
+        Check that the ObservationMetaDataGenerator can query on the 'night'
+        column in the OpSim summary table
+        """
+
+        # the test database goes from night=0 to night=28
+        # corresponding to 49353.032079 <= mjd <= 49381.38533
+        night0 = 49353.0
+
+        results = self.gen.getObservationMetaData(night=(11, 13))
+        self.assertGreater(len(results), 0)
+        for obs in results:
+            self.assertGreater(obs.mjd.TAI, night0+11.0)
+            self.assertLess(obs.mjd.TAI, night0+13.0)
+            self.assertGreater(obs._OpsimMetaData['night'], 11)
+            self.assertLess(obs._OpsimMetaData['night'], 13)
+
     def testCreationOfPhoSimCatalog(self):
         """
         Make sure that we can create PhoSim input catalogs using the returned

--- a/tests/testObservationMetaDataGenerator.py
+++ b/tests/testObservationMetaDataGenerator.py
@@ -399,7 +399,11 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
         night0 = 49353.032079
 
         results = self.gen.getObservationMetaData(night=(11, 13))
-        self.assertGreater(len(results), 0)
+
+        self.assertGreater(len(results), 1800)
+        # there should be about 700 observations a night;
+        # make sure we get at least 600
+
         for obs in results:
             self.assertGreaterEqual(obs.mjd.TAI, night0+11.0)
             self.assertLessEqual(obs.mjd.TAI, night0+13.5)
@@ -407,6 +411,18 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
             # 13 days and 8 hours after the first observation on night 0
             self.assertGreaterEqual(obs._OpsimMetaData['night'], 11)
             self.assertLessEqual(obs._OpsimMetaData['night'], 13)
+
+        # query for an exact night
+        results = self.gen.getObservationMetaData(night=15)
+
+        self.assertGreater(len(results), 600)
+        # there should be about 700 observations a night;
+        # make sure we get at least 600
+
+        for obs in results:
+            self.assertEqual(obs._OpsimMetaData['night'], 15)
+            self.assertGreaterEqual(obs.mjd.TAI, night0+14.9)
+            self.assertLessEqual(obs.mjd.TAI, night0+15.9)
 
     def testCreationOfPhoSimCatalog(self):
         """

--- a/tests/testObservationMetaDataGenerator.py
+++ b/tests/testObservationMetaDataGenerator.py
@@ -105,6 +105,18 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
         self.assertRaises(RuntimeError, gen.getObservationMetaData)
         self.assertRaises(RuntimeError, gen.getObservationMetaData, fieldRA=(1.0, 2.0, 3.0))
 
+    def testOrderBy(self):
+        """
+        Test that the ObservationMetaData really do get ordered on expMJD
+        """
+        results = self.gen.getObservationMetaData(altitude=(50.0, 80.0), limit=100)
+        self.assertEqual(len(results), 100)
+        for ix, obs in enumerate(results):
+            self.assertGreaterEqual(obs.OpsimMetaData['altitude'], np.radians(50.0))
+            self.assertLessEqual(obs.OpsimMetaData['altitude'], np.radians(80.0))
+            if ix>1:
+                self.assertGreater(obs.mjd.TAI, results[ix-1].mjd.TAI)
+
     def testQueryOnRanges(self):
         """
         Test that ObservationMetaData objects returned by queries of the form

--- a/tests/testObservationMetaDataGenerator.py
+++ b/tests/testObservationMetaDataGenerator.py
@@ -409,8 +409,8 @@ class ObservationMetaDataGeneratorTest(unittest.TestCase):
             self.assertLessEqual(obs.mjd.TAI, night0+13.5)
             # the 0.5 is there because the last observation on night 13 could be
             # 13 days and 8 hours after the first observation on night 0
-            self.assertGreaterEqual(obs._OpsimMetaData['night'], 11)
-            self.assertLessEqual(obs._OpsimMetaData['night'], 13)
+            self.assertGreaterEqual(obs.OpsimMetaData['night'], 11)
+            self.assertLessEqual(obs.OpsimMetaData['night'], 13)
 
         # query for an exact night
         results = self.gen.getObservationMetaData(night=15)


### PR DESCRIPTION
In order to be able to use the ObservationMetaDataGenerator in alertsim, we need to be able to

1) query the OpSim database based on the 'night' column
2) query the OpSim database based on an arbitrary, user-specified SQL 'where' clause

This PR adds those capabilities.