### PR TITLE
fix pupil coordinate getter method

### DIFF
--- a/python/lsst/sims/catUtils/mixins/AstrometryMixin.py
+++ b/python/lsst/sims/catUtils/mixins/AstrometryMixin.py
@@ -5,6 +5,7 @@ from lsst.sims.utils import _galacticFromEquatorial, sphericalFromCartesian, \
 
 from lsst.sims.utils import _applyProperMotion
 from lsst.sims.utils import _observedFromICRS, _pupilCoordsFromRaDec
+from lsst.sims.utils import _pupilCoordsFromObserved
 from lsst.sims.utils import rotationMatrixFromVectors
 from lsst.sims.coordUtils.CameraUtils import chipNameFromPupilCoords, pixelCoordsFromPupilCoords
 from lsst.sims.coordUtils.CameraUtils import focalPlaneCoordsFromPupilCoords
@@ -42,13 +43,11 @@ class AstrometryBase(object):
         in the pupil.
         """
 
-        # these coordinates will be the mean RA, Dec from the catalog
-        # with proper motion applied
-        raObj = self.column_by_name('raICRS')
-        decObj = self.column_by_name('decICRS')
+        raObs = self.column_by_name('raObserved')
+        decObs = self.column_by_name('decObserved')
 
-        return _pupilCoordsFromRaDec(raObj, decObj, epoch=self.db_obj.epoch,
-                                     obs_metadata=self.obs_metadata)
+        return _pupilCoordsFromObserved(raObs, decObs, epoch=self.db_obj.epoch,
+                                        obs_metadata=self.obs_metadata)
 
 
 class CameraCoords(AstrometryBase):

--- a/tests/testAstrometryMixins.py
+++ b/tests/testAstrometryMixins.py
@@ -52,6 +52,7 @@ class testCatalog(InstanceCatalog, AstrometryStars, CameraCoords):
     """
     catalog_type = __file__ + 'test_stars'
     column_outputs = ['id', 'raICRS', 'decICRS',
+                      'parallax', 'radial_velocity',
                       'x_pupil', 'y_pupil',
                       'chipName', 'xPix', 'yPix', 'xFocalPlane', 'yFocalPlane']
     # Needed to do camera coordinate transforms.
@@ -216,6 +217,7 @@ class astrometryUnitTest(unittest.TestCase):
 
         dtype = [('id', int),
                  ('raICRS', float), ('decICRS', float),
+                 ('parallax', float), ('radial_velocity', float),
                  ('x_pupil', float), ('y_pupil', float), ('chipName', str, 11),
                  ('xPix', float), ('yPix', float),
                  ('xFocalPlane', float), ('yFocalPlane', float)]
@@ -226,6 +228,8 @@ class astrometryUnitTest(unittest.TestCase):
 
         pupilTest = _pupilCoordsFromRaDec(baselineData['raICRS'],
                                           baselineData['decICRS'],
+                                          parallax=baselineData['parallax'],
+                                          v_rad=baselineData['radial_velocity'],
                                           obs_metadata=self.obs_metadata,
                                           epoch=2000.0)
 
@@ -237,6 +241,8 @@ class astrometryUnitTest(unittest.TestCase):
         focalTest = focalPlaneCoordsFromPupilCoords(pupilTest[0], pupilTest[1], camera=self.cat.camera)
 
         focalRa = _focalPlaneCoordsFromRaDec(baselineData['raICRS'], baselineData['decICRS'],
+                                             parallax=baselineData['parallax'],
+                                             v_rad=baselineData['radial_velocity'],
                                              epoch=self.cat.db_obj.epoch, obs_metadata=self.cat.obs_metadata,
                                              camera=self.cat.camera)
 
@@ -252,6 +258,8 @@ class astrometryUnitTest(unittest.TestCase):
         pixTest = pixelCoordsFromPupilCoords(pupilTest[0], pupilTest[1], camera=self.cat.camera)
 
         pixTestRaDec = _pixelCoordsFromRaDec(baselineData['raICRS'], baselineData['decICRS'],
+                                             parallax=baselineData['parallax'],
+                                             v_rad=baselineData['radial_velocity'],
                                              epoch=self.cat.db_obj.epoch,
                                              obs_metadata=self.cat.obs_metadata,
                                              camera=self.cat.camera)


### PR DESCRIPTION
Since we need to account for parallax motion to correctly
get geocentric apparent RA, Dec, the pupil coordinate
getter will go from ra/decObserved to pupil coordinates,
rather than from ra/decICRS (which has no parallax information)