### PR TITLE
Feature/sim 2249/include dither

### DIFF
--- a/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
+++ b/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
@@ -1,4 +1,5 @@
 import numpy as np
+import os
 from lsst.sims.catalogs.db import DBObject
 from lsst.sims.utils import ObservationMetaData
 
@@ -130,6 +131,9 @@ class ObservationMetaDataGenerator(object):
 
         if self.database is None:
             return
+
+        if not os.path.exists(self.database):
+            raise RuntimeError('%s does not exist' % self.database)
 
         self.opsimdb = DBObject(driver=self.driver, database=self.database,
                                 host=self.host, port=self.port)

--- a/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
+++ b/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
@@ -149,6 +149,12 @@ class ObservationMetaDataGenerator(object):
         dtypeList = []
         self.baseQuery = 'SELECT'
         self.active_columns = []
+
+        self._queried_columns = []  # This will be a list of all of the
+                                    # OpSim columns queried
+                                    # Note: here we will refer to the
+                                    # columns by their names in OpSim
+
         for column in self._user_interface_to_opsim:
             rec = self._user_interface_to_opsim[column]
             if rec[0] in self._summary_columns:
@@ -157,6 +163,16 @@ class ObservationMetaDataGenerator(object):
                 if self.baseQuery != 'SELECT':
                     self.baseQuery += ','
                 self.baseQuery += ' ' + rec[0]
+                self._queried_columns.append(rec[0])
+
+        # Now loop over self._summary_columns, adding any columns
+        # to the query that have not already been included therein.
+        # Since we do not have explicit information about the
+        # data types of these columns, we will assume they are floats.
+        for column in self._summary_columns:
+            if column not in self._queried_columns:
+                self.baseQuery += ', ' + column
+                dtypeList.append((column, float))
 
         self.dtype = np.dtype(dtypeList)
 

--- a/tests/testDitherColumnDetection.py
+++ b/tests/testDitherColumnDetection.py
@@ -1,0 +1,109 @@
+import unittest
+import os
+import sqlite3
+import numpy as np
+
+import lsst.utils.tests
+from lsst.utils import getPackageDir
+from lsst.sims.catUtils.utils import ObservationMetaDataGenerator
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+class ObsMetaDataGenDitherTestClass(unittest.TestCase):
+    """
+    This TestCase will verify that the ObservationMetaDataGenerator
+    puts summary columns which are not hardcoded into its interface
+    into the OpsimMetaData of the ObservationMetaData it creates.
+    """
+
+    @classmethod
+    def tearDownClass(cls):
+        if os.path.exists(cls.fake_db_name):
+            os.unlink(cls.fake_db_name)
+
+    @classmethod
+    def setUpClass(cls):
+        cls.scratch_space = os.path.join(getPackageDir('sims_catUtils'),
+                                         'tests', 'scratchSpace')
+
+        cls.fake_db_name = os.path.join(cls.scratch_space,
+                                        'dither_test_fake_opsim_sqlite.db')
+
+        if os.path.exists(cls.fake_db_name):
+            os.unlink(cls.fake_db_name)
+
+        conn = sqlite3.connect(cls.fake_db_name)
+        curs = conn.cursor()
+        curs.execute('''CREATE TABLE Summary (fieldRA real, fieldDec real,
+                      obsHistID int, rotSkyPos real, m5 real,
+                      raTestDithering real, decTestDithering real, expMJD real,
+                      filter text)''')
+
+        conn.commit()
+
+        n_ptngs = 10
+        rng = np.random.RandomState(18341)
+        ra_list = rng.random_sample(n_ptngs)*2.0*np.pi
+        dec_list = rng.random_sample(n_ptngs)*np.pi-0.5*np.pi
+        rotSkyPos_list = rng.random_sample(n_ptngs)*np.pi
+        m5_list = rng.random_sample(n_ptngs)*20.0
+        ra_dither_list = ra_list + rng.random_sample(n_ptngs)*0.1+0.1
+        dec_dither_list = dec_list + rng.random_sample(n_ptngs)*0.1+0.1
+        expMJD_list = rng.random_sample(n_ptngs)*1000.0
+
+        cls.db_control = []
+
+        for obsid, (ra, dec, rot, m5, raDith, decDith, mjd) in \
+        enumerate(zip(ra_list, dec_list, rotSkyPos_list, m5_list,
+                      ra_dither_list, dec_dither_list, expMJD_list)):
+
+            cls.db_control.append({'ra': ra, 'dec': dec, 'rot': rot, 'm5': m5,
+                                   'raDith': raDith, 'decDith': decDith, 'mjd': mjd})
+            curs.execute('''INSERT INTO Summary VALUES
+                         (%.12f, %.12f, %d, %.12f, %.12f, %.12f, %.12f, %.12f, '%s')''' %
+                         (ra, dec, obsid, rot, m5, raDith, decDith, mjd, 'g'))
+
+        conn.commit()
+        conn.close()
+
+    def test_query(self):
+        """
+        Use ObservationMetaData to query an OpSim-like database that contains
+        dithering columns.  Make sure that the dithering columns get carried
+        over into the OpsimMetaData of the resulting ObservationMetaData.
+        """
+
+        gen = ObservationMetaDataGenerator(database=self.fake_db_name, driver='sqlite')
+        obs_list = gen.getObservationMetaData(fieldRA=(0.0, 180.0))
+        self.assertGreater(len(obs_list), 0)
+        found_list = []
+        for obs in obs_list:
+            obsid = obs.OpsimMetaData['obsHistID']
+            control_dict = self.db_control[obsid]
+            self.assertAlmostEqual(obs._pointingRA, control_dict['ra'], 11)
+            self.assertAlmostEqual(obs._pointingDec, control_dict['dec'], 11)
+            self.assertAlmostEqual(obs._rotSkyPos, control_dict['rot'], 11)
+            self.assertAlmostEqual(obs.OpsimMetaData['m5'], control_dict['m5'], 11)
+            self.assertAlmostEqual(obs.OpsimMetaData['raTestDithering'], control_dict['raDith'], 11)
+            self.assertAlmostEqual(obs.OpsimMetaData['decTestDithering'], control_dict['decDith'], 11)
+            self.assertAlmostEqual(obs.mjd.TAI, control_dict['mjd'], 11)
+            self.assertEqual(obs.bandpass, 'g')
+            self.assertGreaterEqual(obs.pointingRA, 0.0)
+            self.assertLessEqual(obs.pointingRA, 180.0)
+            found_list.append(obs.OpsimMetaData['obsHistID'])
+
+        # check that the entries not returned do, in fact, violate the query
+        for ix in range(len(self.db_control)):
+            if ix not in found_list:
+                self.assertGreater(self.db_control[ix]['ra'], np.radians(180.0))
+
+
+class MemoryTestClass(lsst.utils.tests.MemoryTestCase):
+    pass
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/testObservationMetaDataGenerator.py
+++ b/tests/testObservationMetaDataGenerator.py
@@ -516,12 +516,15 @@ class ObsMetaDataGenMockOpsimTest(unittest.TestCase):
         a database that does not exist.
         """
 
+        test_name = 'non_existent.db'
         with self.assertRaises(RuntimeError) as context:
-            ObservationMetaDataGenerator(database='non_existent.db',
+            ObservationMetaDataGenerator(database=test_name,
                                          driver='sqlite')
 
         self.assertEqual(context.exception.message,
-                         'non_existent.db does not exist')
+                         '%s does not exist' % test_name)
+
+        self.assertFalse(os.path.exists(test_name))
 
     def testSpatialQuery(self):
         """

--- a/tests/testObservationMetaDataGenerator.py
+++ b/tests/testObservationMetaDataGenerator.py
@@ -510,6 +510,19 @@ class ObsMetaDataGenMockOpsimTest(unittest.TestCase):
     def tearDown(self):
         del self.obs_meta_gen
 
+    def testOnNonExistentDatabase(self):
+        """
+        Test that an exception is raised if you try to connect to an query
+        a database that does not exist.
+        """
+
+        with self.assertRaises(RuntimeError) as context:
+            ObservationMetaDataGenerator(database='non_existent.db',
+                                         driver='sqlite')
+
+        self.assertEqual(context.exception.message,
+                         'non_existent.db does not exist')
+
     def testSpatialQuery(self):
         """
         Test that when we run a spatial query on the mock opsim database, we get expected results.


### PR DESCRIPTION
`ObservationMetaDataGenerator` is a tool to read and query OpSim databases, returning `ObservationMetaData` formatted for interface with CatSim.  Currently, the `ObservationMetaDataGenerator` only knows about summary table columns that are hard-coded into its interface.  This pull request will give the `ObservationMetaDataGenerator` the ability to 'learn' about other columns, allowing it to pass along dither columns produced by arbitrary after-burners, storing them in the `OpsimMetaData` associated with the `ObservationMetaData` it produces.