### PR TITLE
U/danielsf/debug/profile lightcurve

### DIFF
--- a/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
+++ b/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
@@ -672,7 +672,7 @@ class MLTflaringMixin(Variability):
             time_arr = self._survey_start + raw_time_arr
             dt = time_arr.max() - time_arr.min()
 
-            t_interp = (self.obs_metadata.mjd.TAI + params['t0'][use_this_lc]).astype(float)
+            t_interp = (expmjd + params['t0'][use_this_lc]).astype(float)
             while t_interp.max() > time_arr.max():
                 bad_dexes = numpy.where(t_interp>time_arr.max())
                 t_interp[bad_dexes] -= dt

--- a/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
+++ b/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
@@ -532,7 +532,9 @@ class StellarVariabilityModels(Variability):
             #black hole.  These also can be used to simulate binary systems.
             #Should be 8kpc away at least.
             magnification = InterpolatedUnivariateSpline(lc[0], lc[1])
-            moff = -2.5*numpy.log(magnification(epoch))
+            mag_val = magnification(epoch)
+            mag_val = numpy.where(numpy.isnan(mag_val), 1.0, mag_val)
+            moff = -2.5*numpy.log(mag_val)
             for ii in range(6):
                 magoff[ii][ix] = moff
 

--- a/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
+++ b/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
@@ -440,19 +440,27 @@ class StellarVariabilityModels(Variability):
         #At some point, either this method or the Amcvn tables in the
         #database will need to be changed.
 
-        if not isinstance(expmjd_in, numbers.Number):
-            raise RuntimeError("Cannot pass multiple expMJD into applyAmcvn")
-
         if len(params) == 0:
             return numpy.array([[],[],[],[],[],[]])
 
         maxyears = 10.
-        dMag = numpy.zeros((6, self.num_variable_obj(params)))
+        if isinstance(expmjd_in, numbers.Number):
+            dMag = numpy.zeros((6, self.num_variable_obj(params)))
+            amplitude = params['amplitude'].astype(float)[valid_dexes]
+            t0_arr = params['t0'].astype(float)[valid_dexes]
+            period = params['period'].astype(float)[valid_dexes]
+            epoch_arr = expmjd_in
+        else:
+            dMag = numpy.zeros((6, self.num_variable_obj(params), len(expmjd_in)))
+            n_time = len(expmjd_in)
+            t0_arr = numpy.array([[tt]*n_time for tt in params['t0'].astype(float)[valid_dexes]])
+            amplitude = numpy.array([[aa]*n_time for aa in params['amplitude'].astype(float)[valid_dexes]])
+            period = numpy.array([[pp]*n_time for pp in params['period'].astype(float)[valid_dexes]])
+            epoch_arr = numpy.array([expmjd_in]*len(valid_dexes[0]))
+
         epoch = expmjd_in
 
-        amplitude = params['amplitude'].astype(float)[valid_dexes]
         t0 = params['t0'].astype(float)[valid_dexes]
-        period = params['period'].astype(float)[valid_dexes]
         burst_freq = params['burst_freq'].astype(float)[valid_dexes]
         burst_scale = params['burst_scale'].astype(float)[valid_dexes]
         amp_burst = params['amp_burst'].astype(float)[valid_dexes]
@@ -460,7 +468,7 @@ class StellarVariabilityModels(Variability):
         does_burst = params['does_burst'][valid_dexes]
 
         # get the light curve of the typical variability
-        uLc   = amplitude*numpy.cos((epoch - t0)/period)
+        uLc   = amplitude*numpy.cos((epoch_arr - t0_arr)/period)
         gLc   = copy.deepcopy(uLc)
         rLc   = copy.deepcopy(uLc)
         iLc   = copy.deepcopy(uLc)

--- a/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
+++ b/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
@@ -559,17 +559,7 @@ class MLTflaringMixin(Variability):
     def applyMLTflaring(self, valid_dexes, params, expmjd,
                         parallax=None, ebv=None, quiescent_mags=None):
 
-        if parallax is None:
-            parallax = self.column_by_name('parallax')
-        if ebv is None:
-            ebv = self.column_by_name('ebv')
-        if quiescent_mags is None:
-            quiescent_mags = {}
-            for mag_name in ('u', 'g', 'r', 'i', 'z', 'y'):
-                if ('lsst_%s' % mag_name in self._actually_calculated_columns or
-                    'delta_lsst_%s' % mag_name in self._actually_calculated_columns):
 
-                    quiescent_mags[mag_name] = self.column_by_name('quiescent_lsst_%s' % mag_name)
 
         global _MLT_LC_NPZ
         global _MLT_LC_NPZ_NAME
@@ -581,6 +571,18 @@ class MLTflaringMixin(Variability):
         # file by hand before generating the catalog
         if len(params) == 0:
             return numpy.array([[],[],[],[],[],[]])
+
+        if parallax is None:
+            parallax = self.column_by_name('parallax')
+        if ebv is None:
+            ebv = self.column_by_name('ebv')
+        if quiescent_mags is None:
+            quiescent_mags = {}
+            for mag_name in ('u', 'g', 'r', 'i', 'z', 'y'):
+                if ('lsst_%s' % mag_name in self._actually_calculated_columns or
+                    'delta_lsst_%s' % mag_name in self._actually_calculated_columns):
+
+                    quiescent_mags[mag_name] = self.column_by_name('quiescent_lsst_%s' % mag_name)
 
         if not hasattr(self, 'photParams'):
             raise RuntimeError("To apply MLT dwarf flaring, your "

--- a/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
+++ b/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
@@ -558,8 +558,18 @@ class MLTflaringMixin(Variability):
     @register_method('MLT')
     def applyMLTflaring(self, valid_dexes, params, expmjd,
                         parallax=None, ebv=None, quiescent_mags=None):
+        """
+        parallax, ebv, and quiescent_mags are optional kwargs for use if you are
+        calling this method outside the context of an InstanceCatalog (presumably
+        with a numpy array of expmjd)
 
+        parallax is the parallax of your objects in radians
 
+        ebv is the E(B-V) value for your objects
+
+        quiescent_mags is a dict keyed on ('u', 'g', 'r', 'i', 'z', 'y')
+        with the quiescent magnitudes of the objects
+        """
 
         global _MLT_LC_NPZ
         global _MLT_LC_NPZ_NAME

--- a/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
+++ b/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
@@ -536,6 +536,8 @@ class StellarVariabilityModels(Variability):
             #Should be 8kpc away at least.
             magnification = InterpolatedUnivariateSpline(lc[0], lc[1])
             mag_val = magnification(epoch)
+            # If we are interpolating out of the light curve's domain, set
+            # the magnification equal to 1
             mag_val = numpy.where(numpy.isnan(mag_val), 1.0, mag_val)
             moff = -2.5*numpy.log(mag_val)
             for ii in range(6):

--- a/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
+++ b/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
@@ -379,17 +379,17 @@ class StellarVariabilityModels(Variability):
             return numpy.array([[],[],[],[],[],[]])
 
         keymap = {'filename':'lcfile', 't0':'t0'}
-        dMags = self.applyStdPeriodic(valid_dexes, params, keymap, expmjd,
-                                      inDays=False,
-                                      interpFactory=InterpolatedUnivariateSpline)
-        if len(dMags)>0:
-            if dMags.min()<0.0:
+        d_fluxes = self.applyStdPeriodic(valid_dexes, params, keymap, expmjd,
+                                         inDays=False,
+                                          interpFactory=InterpolatedUnivariateSpline)
+        if len(d_fluxes)>0:
+            if d_fluxes.min()<0.0:
                 raise RuntimeError("Negative delta flux in applyEb")
         if isinstance(expmjd, numbers.Number):
             dMags = numpy.zeros((6, self.num_variable_obj(params)))
         else:
             dMags = numpy.zeros((6, self.num_variable_obj(params), len(expmjd)))
-        dmag_vals = -2.5*numpy.log10(dMags)
+        dmag_vals = -2.5*numpy.log10(d_fluxes)
         dMags += numpy.where(numpy.logical_not(numpy.logical_or(numpy.isnan(dmag_vals), numpy.isinf(dmag_vals))),
                              dmag_vals, 0.0)
         return dMags

--- a/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
+++ b/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
@@ -556,10 +556,20 @@ class MLTflaringMixin(Variability):
                                 'catUtilsData', 'mdwarf_flare_light_curves_170412.npz')
 
     @register_method('MLT')
-    def applyMLTflaring(self, valid_dexes, params, expmjd):
+    def applyMLTflaring(self, valid_dexes, params, expmjd,
+                        parallax=None, ebv=None, quiescent_mags=None):
 
-        parallax = self.column_by_name('parallax')
-        ebv = self.column_by_name('ebv')
+        if parallax is None:
+            parallax = self.column_by_name('parallax')
+        if ebv is None:
+            ebv = self.column_by_name('ebv')
+        if quiescent_mags is None:
+            quiescent_mags = {}
+            for mag_name in ('u', 'g', 'r', 'i', 'z', 'y'):
+                if ('lsst_%s' % mag_name in self._actually_calculated_columns or
+                    'delta_lsst_%s' % mag_name in self._actually_calculated_columns):
+
+                    quiescent_mags[mag_name] = self.column_by_name('quiescent_lsst_%s' % mag_name)
 
         global _MLT_LC_NPZ
         global _MLT_LC_NPZ_NAME
@@ -666,7 +676,7 @@ class MLTflaringMixin(Variability):
             if ('lsst_%s' % mag_name in self._actually_calculated_columns or
                 'delta_lsst_%s' % mag_name in self._actually_calculated_columns):
 
-                mm = self.column_by_name('quiescent_lsst_%s' % mag_name)
+                mm = quiescent_mags[mag_name]
                 base_mags[mag_name] = mm
                 base_fluxes[mag_name] = ss.fluxFromMag(mm)
 

--- a/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
+++ b/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
@@ -408,11 +408,20 @@ class StellarVariabilityModels(Variability):
         if len(params) == 0:
             return numpy.array([[],[],[],[],[],[]])
 
-        dMags = numpy.zeros((6, self.num_variable_obj(params)))
         expmjd = numpy.asarray(expmjd_in,dtype=float)
-        epochs = expmjd - params['t0'][valid_dexes].astype(float)
-        umin = params['umin'].astype(float)[valid_dexes]
-        that = params['that'].astype(float)[valid_dexes]
+        if isinstance(expmjd_in, numbers.Number):
+            dMags = numpy.zeros((6, self.num_variable_obj(params)))
+            epochs = expmjd - params['t0'][valid_dexes].astype(float)
+            umin = params['umin'].astype(float)[valid_dexes]
+            that = params['that'].astype(float)[valid_dexes]
+        else:
+            dMags = numpy.zeros((6, self.num_variable_obj(params), len(expmjd)))
+            # cast epochs, umin, that into 2-D numpy arrays; the first index will iterate
+            # over objects; the second index will iterate over times in expmjd
+            epochs = numpy.array([expmjd - t0 for t0 in params['t0'][valid_dexes].astype(float)])
+            umin = numpy.array([[uu]*len(expmjd) for uu in params['umin'].astype(float)[valid_dexes]])
+            that = numpy.array([[tt]*len(expmjd) for tt in params['that'].astype(float)[valid_dexes]])
+
         u = numpy.sqrt(umin**2 + ((2.0*epochs/that)**2))
         magnification = (u**2+2.0)/(u*numpy.sqrt(u**2+4.0))
         dmag = -2.5*numpy.log10(magnification)

--- a/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
+++ b/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
@@ -287,7 +287,10 @@ class Variability(object):
         row is an LSST band in ugrizy order.  Each column is a different
         astrophysical object from the CatSim database.
         """
-        magoff = numpy.zeros((6, self.num_variable_obj(params)))
+        if isinstance(expmjd, numbers.Number):
+            magoff = numpy.zeros((6, self.num_variable_obj(params)))
+        else:
+            magoff = numpy.zeros((6, self.num_variable_obj(params), len(expmjd)))
         expmjd = numpy.asarray(expmjd)
         for ix in valid_dexes[0]:
             filename = params[keymap['filename']][ix]

--- a/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
+++ b/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
@@ -3,22 +3,48 @@ This module defines methods which implement the astrophysical
 variability models used by CatSim.  InstanceCatalogs apply
 variability by calling the applyVariability() method in
 the Variability class.  To add a new variability model to
-this framework, users should define a method which accepts
-as arguments:
+this framework, users should define a method which
+returns the delta magnitude of the variable source
+in the LSST bands and accepts as arguments:
 
-valid_dexes -- the output of numpy.where() indicating
-which astrophysical objects actually depend on the
-variability model.
+    valid_dexes -- the output of numpy.where() indicating
+    which astrophysical objects actually depend on the
+    variability model.
 
-params -- a dict whose keys are the names of parameters
-required by the variability model and whose values
-are lists of the parameters required for the
-variability model for all astrophysical objects
-in the CatSim database (even those objects that do
-not depend on the model; these objects can have
-None in the parameter lists).
+    params -- a dict whose keys are the names of parameters
+    required by the variability model and whose values
+    are lists of the parameters required for the
+    variability model for all astrophysical objects
+    in the CatSim database (even those objects that do
+    not depend on the model; these objects can have
+    None in the parameter lists).
 
-expmjd -- the MJD of the observation.
+    expmjd -- the MJD of the observation.  This must be
+    able to accept a float or a numpy array.
+
+If expmjd is a float, the variability model should
+return a 2-D numpy array in which the first index
+varies over the band and the second index varies
+over the object, i.e.
+
+    out_dmag[0][2] is the delta magnitude of the 2nd object
+    in the u band
+
+    out_dmag[3][15] is the delta magnitude of the 15th object
+    in the i band.
+
+If expmjd is a numpy array, the variability should
+return a 3-D numpy array in which the first index
+varies over the band, the second index varies over
+the object, and the third index varies over the
+time step, i.e.
+
+    out_dmag[0][2][15] is the delta magnitude of the 2nd
+    object in the u band at the 15th value of expmjd
+
+    out_dmag[3][11][2] is the delta magnitude of the
+    11th object in the i band at the 2nd value of
+    expmjd
 
 The method implementing the variability model should be
 marked with the decorator @register_method(key) where key

--- a/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
+++ b/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
@@ -385,7 +385,13 @@ class StellarVariabilityModels(Variability):
         if len(dMags)>0:
             if dMags.min()<0.0:
                 raise RuntimeError("Negative delta flux in applyEb")
-        dMags = -2.5*numpy.log10(dMags)
+        if isinstance(expmjd, numbers.Number):
+            dMags = numpy.zeros((6, self.num_variable_obj(params)))
+        else:
+            dMags = numpy.zeros((6, self.num_variable_obj(params), len(expmjd)))
+        dmag_vals = -2.5*numpy.log10(dMags)
+        dMags += numpy.where(numpy.logical_not(numpy.logical_or(numpy.isnan(dmag_vals), numpy.isinf(dmag_vals))),
+                             dmag_vals, 0.0)
         return dMags
 
     @register_method('applyMicrolensing')

--- a/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
+++ b/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
@@ -127,7 +127,7 @@ class Variability(object):
 
 
 
-    def applyVariability(self, varParams_arr):
+    def applyVariability(self, varParams_arr, expmjd=None):
         """
         Read in an array/list of varParamStr objects taken from the CatSim
         database.  For each varParamStr, call the appropriate variability
@@ -151,10 +151,15 @@ class Variability(object):
         if self.variabilityInitialized == False:
             self.initializeVariability(doCache=True)
 
-        # A numpy array of magnitude offsets.  Each row is
-        # an LSST band in ugrizy order.  Each column is an
-        # astrophysical object from the CatSim database.
-        deltaMag = numpy.zeros((6, len(varParams_arr)))
+
+        if isinstance(expmjd, numbers.Number) or expmjd is None:
+            # A numpy array of magnitude offsets.  Each row is
+            # an LSST band in ugrizy order.  Each column is an
+            # astrophysical object from the CatSim database.
+            deltaMag = numpy.zeros((6, len(varParams_arr)))
+        else:
+            # the last dimension varies over time
+            deltaMag = numpy.zeros((6, len(varParams_arr), len(expmjd)))
 
         # When the InstanceCatalog calls all of its getters
         # with an empty chunk to check column dependencies,
@@ -223,8 +228,6 @@ class Variability(object):
         for method_name in params:
             for p_name in params[method_name]:
                 params[method_name][p_name] = numpy.array(params[method_name][p_name])
-
-        expmjd=None
 
         # Loop over all of the variability models that need to be called.
         # Call each variability model on the astrophysical objects that

--- a/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
+++ b/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
@@ -825,7 +825,12 @@ class _VariabilityPointSources(object):
         """
 
         varParams = self.column_by_name('varParamStr')
-        return self.applyVariability(varParams)
+        dmag = self.applyVariability(varParams)
+        if dmag.shape != (6, len(varParams)):
+            raise RuntimeError("applyVariability is returning "
+                               "an array of shape %s\n" % dmag.shape
+                               + "should be (6, %d)" % len(varParams))
+        return dmag
 
 
 class VariabilityStars(_VariabilityPointSources, StellarVariabilityModels,
@@ -900,4 +905,9 @@ class VariabilityGalaxies(ExtraGalacticVariabilityModels):
         the baseline magnitude.
         """
         varParams = self.column_by_name("varParamStr")
-        return self.applyVariability(varParams)
+        dmag = self.applyVariability(varParams)
+        if dmag.shape != (6, len(varParams)):
+            raise RuntimeError("applyVariability is returning "
+                               "an array of shape %s\n" % dmag.shape
+                               + "should be (6, %d)" % len(varParams))
+        return dmag

--- a/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
+++ b/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
@@ -513,7 +513,10 @@ class StellarVariabilityModels(Variability):
         if len(params) == 0:
             return numpy.array([[],[],[],[],[],[]])
 
-        magoff = numpy.zeros((6, self.num_variable_obj(params)))
+        if isinstance(expmjd_in, numbers.Number):
+            magoff = numpy.zeros((6, self.num_variable_obj(params)))
+        else:
+            magoff = numpy.zeros((6, self.num_variable_obj(params), len(expmjd_in)))
         expmjd = numpy.asarray(expmjd_in,dtype=float)
         filename_arr = params['filename']
         toff_arr = params['t0'].astype(float)

--- a/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
+++ b/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
@@ -571,6 +571,11 @@ class MLTflaringMixin(Variability):
         with the quiescent magnitudes of the objects
         """
 
+        if parallax is None:
+            parallax = self.column_by_name('parallax')
+        if ebv is None:
+            ebv = self.column_by_name('ebv')
+
         global _MLT_LC_NPZ
         global _MLT_LC_NPZ_NAME
         global _MLT_LC_TIME_CACHE
@@ -582,10 +587,6 @@ class MLTflaringMixin(Variability):
         if len(params) == 0:
             return numpy.array([[],[],[],[],[],[]])
 
-        if parallax is None:
-            parallax = self.column_by_name('parallax')
-        if ebv is None:
-            ebv = self.column_by_name('ebv')
         if quiescent_mags is None:
             quiescent_mags = {}
             for mag_name in ('u', 'g', 'r', 'i', 'z', 'y'):

--- a/python/lsst/sims/catUtils/utils/CatalogTestUtils.py
+++ b/python/lsst/sims/catUtils/utils/CatalogTestUtils.py
@@ -7,6 +7,7 @@ To date (30 October 2014) testPhotometryMixins.py and testCosmologyMixins.py imp
 from builtins import range
 from builtins import object
 import numpy
+import numbers
 import os
 import sqlite3
 import json
@@ -199,9 +200,15 @@ class TestVariabilityMixin(Variability):
             return numpy.array([[],[],[],[],[],[]])
 
         period = varParams['period'][valid_dexes]
-        amplitude = varParams['amplitude'][valid_dexes]
-        phase = expmjd%period
-        magoff = numpy.zeros((6, self.num_variable_obj(varParams)))
+        if isinstance(expmjd, numbers.Number):
+            magoff = numpy.zeros((6, self.num_variable_obj(varParams)))
+            phase = expmjd%period
+            amplitude = varParams['amplitude'][valid_dexes]
+        else:
+            magoff = numpy.zeros((6, self.num_variable_obj(varParams), len(expmjd)))
+            phase = numpy.array([expmjd%pp for pp in period])
+            amplitude = numpy.array([[aa]*len(expmjd)
+                                     for aa in varParams['amplitude'][valid_dexes]])
         delta = amplitude*numpy.sin(2*numpy.pi*phase.astype(float))
         delta = delta.astype(float)
         for ix in range(6):

--- a/python/lsst/sims/catUtils/utils/LightCurveGenerator.py
+++ b/python/lsst/sims/catUtils/utils/LightCurveGenerator.py
@@ -784,7 +784,8 @@ class StellarLightCurveGenerator(LightCurveGenerator):
         super(StellarLightCurveGenerator, self).__init__(*args, **kwargs)
 
 
-class FastStellarLightCurveGenerator(FastLightCurveGenerator, StellarLightCurveGenerator):
+class FastStellarLightCurveGenerator(FastLightCurveGenerator,
+                                     StellarLightCurveGenerator):
 
     def delta_name_mapper(self, bp):
         return 'delta_lsst_%s' % bp

--- a/python/lsst/sims/catUtils/utils/LightCurveGenerator.py
+++ b/python/lsst/sims/catUtils/utils/LightCurveGenerator.py
@@ -18,6 +18,7 @@ import time
 __all__ = ["StellarLightCurveGenerator",
            "FastStellarLightCurveGenerator",
            "AgnLightCurveGenerator",
+           "FastAgnLightCurveGenerator",
            "_baseLightCurveCatalog",
            "LightCurveGenerator",
            "FastLightCurveGenerator"]
@@ -815,3 +816,13 @@ class AgnLightCurveGenerator(LightCurveGenerator):
         self._lightCurveCatalogClass = _agnLightCurveCatalog
         self._constraint = 'varParamStr IS NOT NULL'
         super(AgnLightCurveGenerator, self).__init__(*args, **kwargs)
+
+
+class FastAgnLightCurveGenerator(FastLightCurveGenerator,
+                                 AgnLightCurveGenerator):
+
+    def delta_name_mapper(self, bp):
+        return 'delta_%sAgn' % bp
+
+    def total_name_mapper(self, bp):
+        return '%sAgn' % bp

--- a/python/lsst/sims/catUtils/utils/LightCurveGenerator.py
+++ b/python/lsst/sims/catUtils/utils/LightCurveGenerator.py
@@ -27,7 +27,7 @@ class _baseLightCurveCatalog(InstanceCatalog):
 
     column_outputs = ["uniqueId", "raJ2000", "decJ2000",
                       "lightCurveMag", "sigma_lightCurveMag",
-                      "truthInfo"]
+                      "truthInfo", "quiescent_lightCurveMag"]
 
     def iter_catalog(self, chunk_size=None, query_cache=None):
         """
@@ -124,7 +124,7 @@ class _stellarLightCurveCatalog(_baseLightCurveCatalog, VariabilityStars, Photom
         else:
             self._sedList = copy.copy(_sed_cache[cache_name])
 
-    @compound("lightCurveMag", "sigma_lightCurveMag")
+    @compound("lightCurveMag", "sigma_lightCurveMag", "quiescent_lightCurveMag")
     def get_lightCurvePhotometry(self):
         """
         A getter which returns the magnitudes and uncertainties in magnitudes
@@ -138,8 +138,11 @@ class _stellarLightCurveCatalog(_baseLightCurveCatalog, VariabilityStars, Photom
             raise RuntimeError("_stellarLightCurveCatalog cannot handle bandpass "
                                "%s" % str(self.obs_metadata.bandpass))
 
-        return np.array([self.column_by_name("lsst_%s" % self.obs_metadata.bandpass),
-                         self.column_by_name("sigma_lsst_%s" % self.obs_metadata.bandpass)])
+        bp = self.obs_metadata.bandpass
+
+        return np.array([self.column_by_name("lsst_%s" % bp),
+                         self.column_by_name("sigma_lsst_%s" % bp),
+                         self.column_by_name("lsst_%s" % bp) - self.column_by_name("delta_lsst_%s" % bp)])
 
 
 class _agnLightCurveCatalog(_baseLightCurveCatalog, VariabilityGalaxies, PhotometryGalaxies):
@@ -175,7 +178,7 @@ class _agnLightCurveCatalog(_baseLightCurveCatalog, VariabilityGalaxies, Photome
         else:
             self._agnSedList = copy.copy(_sed_cache[cache_name])
 
-    @compound("lightCurveMag", "sigma_lightCurveMag")
+    @compound("lightCurveMag", "sigma_lightCurveMag", "quiescent_lightCurveMag")
     def get_lightCurvePhotometry(self):
         """
         A getter which returns the magnitudes and uncertainties in magnitudes
@@ -189,8 +192,11 @@ class _agnLightCurveCatalog(_baseLightCurveCatalog, VariabilityGalaxies, Photome
             raise RuntimeError("_agnLightCurveCatalog cannot handle bandpass "
                                "%s" % str(self.obs_metadata.bandpass))
 
-        return np.array([self.column_by_name("%sAgn" % self.obs_metadata.bandpass),
-                         self.column_by_name("sigma_%sAgn" % self.obs_metadata.bandpass)])
+        bp = self.obs_metadata.bandpass
+
+        return np.array([self.column_by_name("%sAgn" % bp),
+                         self.column_by_name("sigma_%sAgn" % bp),
+                         self.column_by_name("%sAgn" % bp) - self.column_by_name("delta_%sAgn" % bp)])
 
 
 class LightCurveGenerator(object):

--- a/python/lsst/sims/catUtils/utils/LightCurveGenerator.py
+++ b/python/lsst/sims/catUtils/utils/LightCurveGenerator.py
@@ -684,8 +684,8 @@ class FastLightCurveGenerator(LightCurveGenerator):
                     for star_obj in cat.iter_catalog(query_cache=[chunk]):
                         local_quiescent_mags.append(star_obj[6])
                     quiescent_mags[bp] = np.array(local_quiescent_mags)
-                    if 'delta_lsst_%s' % bp not in cat._actually_calculated_columns:
-                        cat._actually_calculated_columns.append('delta_lsst_%s' % bp)
+                    if self.delta_name_mapper(bp) not in cat._actually_calculated_columns:
+                        cat._actually_calculated_columns.append(self.delta_name_mapper(bp))
                     varparamstr = cat.column_by_name('varParamStr')
                     temp_d_mags = cat.applyVariability(varparamstr, mjd_arr_dict[bp])
                     d_mags[bp] = temp_d_mags[{'u':0, 'g':1, 'r':2, 'i':3, 'z':4, 'y':5}[bp]].transpose()

--- a/python/lsst/sims/catUtils/utils/LightCurveGenerator.py
+++ b/python/lsst/sims/catUtils/utils/LightCurveGenerator.py
@@ -633,8 +633,15 @@ class FastLightCurveGenerator(LightCurveGenerator):
 
         row_ct = 0
 
-        # a dict containing one ObservationMetaData for each
-        # bandpass we are actually using
+        # assemble dicts needed for data precalculation
+        #
+        # quiescent_ob_dict contains one ObservationMetaData per bandpass
+        #
+        # mjd_arr_dict is a dict of all of the mjd values needed per bandpass
+        #
+        # time_lookup_dict is a dict of dicts; for each bandpass it will
+        # provide a dict that allows you to convert mjd to index in the
+        # mjd_arr_dict[bp] array.
         quiescent_obs_dict = {}
         mjd_arr_dict = {}
         time_lookup_dict = {}
@@ -668,6 +675,8 @@ class FastLightCurveGenerator(LightCurveGenerator):
             if chunk is not None:
                 quiescent_mags = {}
                 d_mags = {}
+                # pre-calculate quiescent magnitudes
+                # and delta magnitude arrays
                 for bp in quiescent_obs_dict:
                     cat = cat_dict[bp]
                     cat.obs_metadata = quiescent_obs_dict[bp]
@@ -686,6 +695,12 @@ class FastLightCurveGenerator(LightCurveGenerator):
                     cat = cat_dict[bp]
                     cat.obs_metadata = obs
                     time_dex = time_lookup_dict[bp][obs.mjd.TAI]
+
+                    # build up a column_cache of the pre-calculated
+                    # magnitudes from above that can be passed into
+                    # our catalog iterators so that the catalogs will
+                    # not spend time computing things that have already
+                    # been calculated
                     local_column_cache = {}
                     delta_name = self.delta_name_mapper(bp)
                     total_name = self.total_name_mapper(bp)

--- a/tests/testFastLightCurveGenerator.py
+++ b/tests/testFastLightCurveGenerator.py
@@ -75,12 +75,12 @@ class FastStellar_stellar_lc_gen_case(unittest.TestCase):
             output_file.write('# a silly header\n')
             sed_dex = rng.random_integers(0, len(list_of_seds)-1, size=cls.n_stars//2)
             lc_dex = rng.random_integers(0, len(list_of_rrly_lc)-1, size=cls.n_stars//2)
-            mjd0 = rng.random_sample(cls.n_stars/2)*10000.0+40000.0
-            raList = rng.random_sample(cls.n_stars/2)*(cls.raRange[1]-cls.raRange[0])+cls.raRange[0]
-            decList = cls.decRange[0] + rng.random_sample(cls.n_stars/2)*(cls.decRange[1]-cls.decRange[1])
-            magNormList = rng.random_sample(cls.n_stars/2)*3.0+14.0
-            AvList = rng.random_sample(cls.n_stars/2)*0.2+0.1
-            pxList = rng.random_sample(cls.n_stars/2)*0.1
+            mjd0 = rng.random_sample(cls.n_stars//2)*10000.0+40000.0
+            raList = rng.random_sample(cls.n_stars//2)*(cls.raRange[1]-cls.raRange[0])+cls.raRange[0]
+            decList = cls.decRange[0] + rng.random_sample(cls.n_stars//2)*(cls.decRange[1]-cls.decRange[1])
+            magNormList = rng.random_sample(cls.n_stars//2)*3.0+14.0
+            AvList = rng.random_sample(cls.n_stars//2)*0.2+0.1
+            pxList = rng.random_sample(cls.n_stars//2)*0.1
             for ix in range(cls.n_stars//2):
                 varparams = {'varMethodName': 'applyRRly',
                              'pars': {'tStartMjd': mjd0[ix],
@@ -97,12 +97,12 @@ class FastStellar_stellar_lc_gen_case(unittest.TestCase):
 
             sed_dex = rng.random_integers(0, len(list_of_seds)-1, size=cls.n_stars//2)
             lc_dex = rng.random_integers(1, 2, size=cls.n_stars//2)
-            mjd0 = rng.random_sample(cls.n_stars/2)*10000.0+40000.0
-            raList = rng.random_sample(cls.n_stars/2)*(cls.raRange[1]-cls.raRange[0])+cls.raRange[0]
-            decList = cls.decRange[0] + rng.random_sample(cls.n_stars/2)*(cls.decRange[1]-cls.decRange[1])
-            magNormList = rng.random_sample(cls.n_stars/2)*3.0+14.0
-            AvList = rng.random_sample(cls.n_stars/2)*0.2+0.1
-            pxList = rng.random_sample(cls.n_stars/2)*0.1
+            mjd0 = rng.random_sample(cls.n_stars//2)*10000.0+40000.0
+            raList = rng.random_sample(cls.n_stars//2)*(cls.raRange[1]-cls.raRange[0])+cls.raRange[0]
+            decList = cls.decRange[0] + rng.random_sample(cls.n_stars//2)*(cls.decRange[1]-cls.decRange[1])
+            magNormList = rng.random_sample(cls.n_stars//2)*3.0+14.0
+            AvList = rng.random_sample(cls.n_stars//2)*0.2+0.1
+            pxList = rng.random_sample(cls.n_stars//2)*0.1
             for ix in range(cls.n_stars//2):
                 varparams = {'m':'MLT', 'p':{'lc':'lc_%d' % lc_dex[ix], 't0':rng.random_sample()*1000.0}}
                 varparamstr = json.dumps(varparams)

--- a/tests/testFastLightCurveGenerator.py
+++ b/tests/testFastLightCurveGenerator.py
@@ -103,7 +103,7 @@ class FastStellar_stellar_lc_gen_case(unittest.TestCase):
             magNormList = rng.random_sample(cls.n_stars/2)*3.0+14.0
             AvList = rng.random_sample(cls.n_stars/2)*0.2+0.1
             pxList = rng.random_sample(cls.n_stars/2)*0.1
-            for ix in range(cls.n_stars/2):
+            for ix in range(cls.n_stars//2):
                 varparams = {'m':'MLT', 'p':{'lc':'lc_%d' % lc_dex[ix], 't0':rng.random_sample()*1000.0}}
                 varparamstr = json.dumps(varparams)
                 output_file.write("%d;%lf;%lf;%lf;%lf;%lf;%lf;%s;%s;%lf;%lf\n"

--- a/tests/testFastLightCurveGenerator.py
+++ b/tests/testFastLightCurveGenerator.py
@@ -10,10 +10,12 @@ from lsst.utils import getPackageDir
 from lsst.sims.catalogs.db import fileDBObject
 from lsst.sims.catUtils.utils import FastStellarLightCurveGenerator
 from lsst.sims.catUtils.utils import StellarLightCurveGenerator
+from lsst.sims.catUtils.utils import AgnLightCurveGenerator
+from lsst.sims.catUtils.utils import FastAgnLightCurveGenerator
 
 from lsst.sims.utils.CodeUtilities import sims_clean_up
 
-class FastStellar_lc_gen_case(unittest.TestCase):
+class FastStellar_stellar_lc_gen_case(unittest.TestCase):
 
     longMessage = True
 
@@ -163,6 +165,134 @@ class FastStellar_lc_gen_case(unittest.TestCase):
 
         for obj_id in fast_truth:
             self.assertEqual(fast_truth[obj_id], slow_truth[obj_id])
+
+
+class Fast_agn_lc_gen_test_case(unittest.TestCase):
+
+    longMessge = True
+
+    @classmethod
+    def setUpClass(cls):
+        rng = np.random.RandomState(119)
+
+        cls.txt_cat_name = os.path.join(getPackageDir("sims_catUtils"), "tests")
+        cls.txt_cat_name = os.path.join(cls.txt_cat_name, "scratchSpace", "fast_agn_lc_cat.txt")
+
+        n_galaxies = 20
+
+        sed_dir = os.path.join(getPackageDir("sims_sed_library"), "galaxySED")
+        list_of_seds = os.listdir(sed_dir)
+        disk_sed_dexes = rng.random_integers(0, len(list_of_seds)-1, size=n_galaxies)
+        bulge_sed_dexes = rng.random_integers(0, len(list_of_seds)-1, size=n_galaxies)
+
+        avBulge = rng.random_sample(n_galaxies)*0.3+0.1
+        avDisk = rng.random_sample(n_galaxies)*0.3+0.1
+
+        mjdList = rng.random_sample(n_galaxies)*10.0+49330.0
+        redshiftList = rng.random_sample(n_galaxies)*1.5+0.01
+
+        tauList = rng.random_sample(n_galaxies)*1.0+1.0
+        sfuList = rng.random_sample(n_galaxies)*2.0+1.0
+        sfgList = rng.random_sample(n_galaxies)*2.0+1.0
+        sfrList = rng.random_sample(n_galaxies)*2.0+1.0
+        sfiList = rng.random_sample(n_galaxies)*2.0+1.0
+        sfzList = rng.random_sample(n_galaxies)*2.0+1.0
+        sfyList = rng.random_sample(n_galaxies)*2.0+1.0
+
+        raList = rng.random_sample(n_galaxies)*7.0+78.0
+        decList = rng.random_sample(n_galaxies)*4.0-69.0
+
+        normDisk = rng.random_sample(n_galaxies)*5.0+20.0
+        normBulge = rng.random_sample(n_galaxies)*5.0+20.0
+        normAgn = rng.random_sample(n_galaxies)*5.0+20.0
+
+        with open(cls.txt_cat_name, "w") as output_file:
+            for ix in range(n_galaxies):
+                varParam = {'varMethodName': 'applyAgn',
+                            'pars': {'agn_tau': tauList[ix], 'agn_sfu': sfuList[ix],
+                                     'agn_sfg': sfgList[ix], 'agn_sfr': sfrList[ix],
+                                     'agn_sfi': sfiList[ix], 'agn_sfz': sfzList[ix],
+                                     'agn_sfy': sfyList[ix], 't0_mjd': mjdList[ix],
+                                     'seed': rng.randint(0, 200000)}}
+
+                paramStr = json.dumps(varParam)
+
+                output_file.write("%d;%f;%f;" % (ix, raList[ix], decList[ix])
+                                  + "%f;%f;" % (np.radians(raList[ix]), np.radians(decList[ix]))
+                                  + "%f;" % (redshiftList[ix])
+                                  + "%s;%f;%f;" % (list_of_seds[disk_sed_dexes[ix]],
+                                                   avDisk[ix], normDisk[ix])
+                                  + "%s;%f;%f;" % (list_of_seds[bulge_sed_dexes[ix]],
+                                                   avBulge[ix], normBulge[ix])
+                                  + "agn.spec;%s;%f\n" % (paramStr, normAgn[ix]))
+
+        dtype = np.dtype([
+                         ('galid', np.int),
+                         ('raDeg', np.float), ('decDeg', np.float),
+                         ('raJ2000', np.float), ('decJ2000', np.float),
+                         ('redshift', np.float),
+                         ('sedFilenameDisk', str, 300), ('internalAvDisk', np.float),
+                         ('magNormDisk', np.float),
+                         ('sedFilenameBulge', str, 300), ('internalAvBulge', np.float),
+                         ('magNormBulge', np.float),
+                         ('sedFilenameAgn', str, 300), ('varParamStr', str, 600),
+                         ('magNormAgn', np.float)
+                         ])
+
+        cls.agn_db = fileDBObject(cls.txt_cat_name, delimiter=';',
+                                  runtable='test', dtype=dtype,
+                                  idColKey='galid')
+
+        cls.agn_db.raColName = 'raDeg'
+        cls.agn_db.decColName = 'decDeg'
+        cls.agn_db.objectTypeId = 112
+
+        # what follows is a hack to deal with the fact thar
+        # our varParamStr values are longer than 256 characters
+        # which is the default maximum length that a
+        # CatalogDBObject expects a string to be
+        #
+        cls.agn_db.dbTypeMap['STRING'] = (str, 600)
+        cls.agn_db.columns = None
+        cls.agn_db._make_default_columns()
+        cls.agn_db._make_column_map()
+        cls.agn_db._make_type_map()
+
+        cls.opsimDb = os.path.join(getPackageDir("sims_data"), "OpSimData")
+        cls.opsimDb = os.path.join(cls.opsimDb, "opsimblitz1_1133_sqlite.db")
+
+    @classmethod
+    def tearDownClass(cls):
+        sims_clean_up()
+        if os.path.exists(cls.txt_cat_name):
+            os.unlink(cls.txt_cat_name)
+
+    def test_fast_agn_light_curves(self):
+        raRange = (78.0, 85.0)
+        decRange = (-69.0, -65.0)
+        bandpass = ('g', 'r')
+
+        slow_lc_gen = AgnLightCurveGenerator(self.agn_db, self.opsimDb)
+        pointings = slow_lc_gen.get_pointings(raRange, decRange, bandpass=bandpass)
+        slow_lc, slow_truth = slow_lc_gen.light_curves_from_pointings(pointings)
+
+        self.assertGreater(len(slow_lc), 2)  # make sure we got some light curves
+
+        fast_lc_gen = FastAgnLightCurveGenerator(self.agn_db, self.opsimDb)
+        pointings = fast_lc_gen.get_pointings(raRange, decRange, bandpass=bandpass)
+        fast_lc, fast_truth = fast_lc_gen.light_curves_from_pointings(pointings)
+
+        self.assertEqual(len(slow_lc), len(fast_lc))
+        self.assertEqual(len(slow_truth), len(fast_truth))
+
+        for obj_id in slow_lc:
+            self.assertEqual(len(fast_lc[obj_id]), len(slow_lc[obj_id]))
+            for bp in fast_lc[obj_id]:
+                self.assertEqual(len(fast_lc[obj_id][bp]), len(slow_lc[obj_id][bp]))
+                for data_key in fast_lc[obj_id][bp]:
+                    self.assertEqual(fast_lc[obj_id][bp][data_key].shape, slow_lc[obj_id][bp][data_key].shape)
+                    self.assertLess(np.abs(fast_lc[obj_id][bp][data_key]-slow_lc[obj_id][bp][data_key]).max(),
+                                    2.0e-10, msg='failed on %d, %s, %s' % (obj_id, bp, data_key))
 
 
 if __name__ == "__main__":

--- a/tests/testFastLightCurveGenerator.py
+++ b/tests/testFastLightCurveGenerator.py
@@ -73,8 +73,8 @@ class FastStellar_stellar_lc_gen_case(unittest.TestCase):
         cls.txt_name = os.path.join(cls.scratchDir, "fast_stellar_lc_catalog.txt")
         with open(cls.txt_name, "w") as output_file:
             output_file.write('# a silly header\n')
-            sed_dex = rng.random_integers(0, len(list_of_seds)-1, size=cls.n_stars/2)
-            lc_dex = rng.random_integers(0, len(list_of_rrly_lc)-1, size=cls.n_stars/2)
+            sed_dex = rng.random_integers(0, len(list_of_seds)-1, size=cls.n_stars//2)
+            lc_dex = rng.random_integers(0, len(list_of_rrly_lc)-1, size=cls.n_stars//2)
             mjd0 = rng.random_sample(cls.n_stars/2)*10000.0+40000.0
             raList = rng.random_sample(cls.n_stars/2)*(cls.raRange[1]-cls.raRange[0])+cls.raRange[0]
             decList = cls.decRange[0] + rng.random_sample(cls.n_stars/2)*(cls.decRange[1]-cls.decRange[1])
@@ -95,8 +95,8 @@ class FastStellar_stellar_lc_gen_case(unittest.TestCase):
                                      varparamstr,pxList[ix],
                                      AvList[ix]/3.1))
 
-            sed_dex = rng.random_integers(0, len(list_of_seds)-1, size=cls.n_stars/2)
-            lc_dex = rng.random_integers(1, 2, size=cls.n_stars/2)
+            sed_dex = rng.random_integers(0, len(list_of_seds)-1, size=cls.n_stars//2)
+            lc_dex = rng.random_integers(1, 2, size=cls.n_stars//2)
             mjd0 = rng.random_sample(cls.n_stars/2)*10000.0+40000.0
             raList = rng.random_sample(cls.n_stars/2)*(cls.raRange[1]-cls.raRange[0])+cls.raRange[0]
             decList = cls.decRange[0] + rng.random_sample(cls.n_stars/2)*(cls.decRange[1]-cls.decRange[1])

--- a/tests/testFastLightCurveGenerator.py
+++ b/tests/testFastLightCurveGenerator.py
@@ -81,7 +81,7 @@ class FastStellar_stellar_lc_gen_case(unittest.TestCase):
             magNormList = rng.random_sample(cls.n_stars/2)*3.0+14.0
             AvList = rng.random_sample(cls.n_stars/2)*0.2+0.1
             pxList = rng.random_sample(cls.n_stars/2)*0.1
-            for ix in range(cls.n_stars/2):
+            for ix in range(cls.n_stars//2):
                 varparams = {'varMethodName': 'applyRRly',
                              'pars': {'tStartMjd': mjd0[ix],
                                       'filename': list_of_rrly_lc[lc_dex[ix]]}}

--- a/tests/testFastLightCurveGenerator.py
+++ b/tests/testFastLightCurveGenerator.py
@@ -1,0 +1,123 @@
+import unittest
+
+import os
+import numpy as np
+import json
+
+import lsst.utils.tests
+from lsst.utils import getPackageDir
+
+from lsst.sims.catalogs.db import fileDBObject
+from lsst.sims.catUtils.utils import FastStellarLightCurveGenerator
+from lsst.sims.catUtils.utils import StellarLightCurveGenerator
+
+from lsst.sims.utils.CodeUtilities import sims_clean_up
+
+class FastStellar_lc_gen_case(unittest.TestCase):
+
+    longMessage = True
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Create a fake catalog of RR Lyrae stars.  Store it in cls.stellar_db
+        """
+        cls.scratchDir = os.path.join(getPackageDir("sims_catUtils"))
+        cls.scratchDir = os.path.join(cls.scratchDir, "tests", "scratchSpace")
+
+        rng = np.random.RandomState(88)
+        n_stars = 10000
+        sed_dir = os.path.join(getPackageDir("sims_sed_library"))
+        sed_dir = os.path.join(sed_dir, "starSED", "kurucz")
+        list_of_seds = os.listdir(sed_dir)
+
+        lc_dir = os.path.join(getPackageDir("sims_sed_library"), "rrly_lc")
+        lc_dir = os.path.join(lc_dir, "RRab")
+        list_of_lc = ['rrly_lc/RRab/%s' % ww for ww in os.listdir(lc_dir) if "per.txt" in ww]
+
+        cls.dtype = np.dtype([('id', np.int),
+                             ('raDeg', np.float),
+                             ('decDeg', np.float),
+                             ('raJ2000', np.float),
+                             ('decJ2000', np.float),
+                             ('magNorm', np.float),
+                             ('galacticAv', np.float),
+                             ('sedFilename', str, 300),
+                             ('varParamStr', str, 300),
+                             ('parallax', np.float),
+                             ('ebv', np.float)])
+
+        # write the catalog as a text file to be ingested with fileDBObject
+        cls.txt_name = os.path.join(cls.scratchDir, "fast_stellar_lc_catalog.txt")
+        with open(cls.txt_name, "w") as output_file:
+            sed_dex = rng.random_integers(0, len(list_of_seds)-1, size=n_stars)
+            lc_dex = rng.random_integers(0, len(list_of_lc)-1, size=n_stars)
+            mjd0 = rng.random_sample(n_stars)*10000.0+40000.0
+            raList = rng.random_sample(n_stars)*360.0
+            decList = -90.0 + rng.random_sample(n_stars)*120.0
+            magNormList = rng.random_sample(n_stars)*3.0+14.0
+            AvList = rng.random_sample(n_stars)*0.2+0.1
+            pxList = rng.random_sample(n_stars)*0.1
+            for ix in range(n_stars):
+                varparams = {'varMethodName': 'applyRRly',
+                             'pars': {'tStartMjd': mjd0[ix],
+                                      'filename': list_of_lc[lc_dex[ix]]}}
+                varparamstr = json.dumps(varparams)
+                output_file.write("%d;%lf;%lf;%lf;%lf;%lf;%lf;%s;%s;%lf;%lf\n"
+                                  % (ix, raList[ix], decList[ix],
+                                     np.radians(raList[ix]),
+                                     np.radians(decList[ix]),
+                                     magNormList[ix], AvList[ix],
+                                     list_of_seds[sed_dex[ix]],
+                                     varparamstr,pxList[ix],
+                                     AvList[ix]/3.1))
+
+        cls.stellar_db = fileDBObject(cls.txt_name, delimiter=';',
+                                      runtable='test', dtype=cls.dtype,
+                                      idColKey='id')
+
+        cls.stellar_db.raColName = 'raDeg'
+        cls.stellar_db.decColName = 'decDeg'
+        cls.stellar_db.objectTypeId = 32
+
+        cls.opsimDb = os.path.join(getPackageDir("sims_data"), "OpSimData")
+        cls.opsimDb = os.path.join(cls.opsimDb, "opsimblitz1_1133_sqlite.db")
+
+    @classmethod
+    def tearDownClass(cls):
+        sims_clean_up()
+        if os.path.exists(cls.txt_name):
+            os.unlink(cls.txt_name)
+
+    def test_fast_stellar_lc_gen(self):
+        raRange = (78.0, 85.0)
+        decRange = (-69.0, -65.0)
+        bandpass = ('r', 'g')
+
+        lc_slow = StellarLightCurveGenerator(self.stellar_db, self.opsimDb)
+        ptngs = lc_slow.get_pointings(raRange, decRange, bandpass=bandpass)
+        slow_lc, slow_truth = lc_slow.light_curves_from_pointings(ptngs, chunk_size=10)
+        self.assertGreater(len(slow_truth), 10)
+
+        lc_fast = FastStellarLightCurveGenerator(self.stellar_db, self.opsimDb)
+        ptngs = lc_fast.get_pointings(raRange, decRange, bandpass=bandpass)
+        fast_lc, fast_truth = lc_fast.light_curves_from_pointings(ptngs, chunk_size=10)
+
+        self.assertEqual(len(fast_lc), len(slow_lc))
+        self.assertEqual(len(fast_truth), len(slow_truth))
+
+        for obj_id in fast_lc:
+            self.assertEqual(len(fast_lc[obj_id]), len(slow_lc[obj_id]))
+            for bp in fast_lc[obj_id]:
+                self.assertEqual(len(fast_lc[obj_id][bp]), len(slow_lc[obj_id][bp]))
+                for data_key in fast_lc[obj_id][bp]:
+                    self.assertLess(np.abs(fast_lc[obj_id][bp][data_key]-slow_lc[obj_id][bp][data_key]).max(),
+                                    1.0e-10)
+
+        for obj_id in fast_truth:
+            self.assertEqual(fast_truth[obj_id], slow_truth[obj_id])
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/testFastLightCurveGenerator.py
+++ b/tests/testFastLightCurveGenerator.py
@@ -20,20 +20,40 @@ class FastStellar_lc_gen_case(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """
-        Create a fake catalog of RR Lyrae stars.  Store it in cls.stellar_db
+        Create a fake catalog of RR Lyrae stars and MLT dwarves with flaring
+        light curves. Store it in cls.stellar_db
         """
         cls.scratchDir = os.path.join(getPackageDir("sims_catUtils"))
         cls.scratchDir = os.path.join(cls.scratchDir, "tests", "scratchSpace")
 
+        cls.raRange = (78.0, 85.0)
+        cls.decRange = (-69.0, -65.0)
+
         rng = np.random.RandomState(88)
-        n_stars = 10000
+        cls.n_stars = 20
         sed_dir = os.path.join(getPackageDir("sims_sed_library"))
         sed_dir = os.path.join(sed_dir, "starSED", "kurucz")
         list_of_seds = os.listdir(sed_dir)
 
         lc_dir = os.path.join(getPackageDir("sims_sed_library"), "rrly_lc")
         lc_dir = os.path.join(lc_dir, "RRab")
-        list_of_lc = ['rrly_lc/RRab/%s' % ww for ww in os.listdir(lc_dir) if "per.txt" in ww]
+        list_of_rrly_lc = ['rrly_lc/RRab/%s' % ww for ww in os.listdir(lc_dir) if "per.txt" in ww]
+
+        cls.mlt_lc_file_name = os.path.join(cls.scratchDir, "fast_lc_mlt_file.npz")
+        if os.path.exists(cls.mlt_lc_file_name):
+            os.unlink(cls.mlt_lc_file_name)
+
+        mlt_lc_files = {}
+        mlt_lc_files['lc_1_time'] = np.arange(0.0, 3652.51, 0.1)
+        mlt_lc_files['lc_1_g'] = 2.2e32*np.power(np.cos(mlt_lc_files['lc_1_time']/100.0-5.0),2)
+        mlt_lc_files['lc_1_r'] = 1.3e32*(1.0+np.sin(mlt_lc_files['lc_1_time']/100.0-3.0))
+
+        mlt_lc_files['lc_2_time'] = np.arange(0.0, 3652.51, 0.1)
+        mlt_lc_files['lc_2_g'] = 5.1e33*(1.0+np.cos(mlt_lc_files['lc_2_time']/300.0-10.0))
+        mlt_lc_files['lc_2_r'] = 4.3e32*(1.0+np.sin(mlt_lc_files['lc_2_time']/50.0-71.0))
+
+        with open(cls.mlt_lc_file_name, 'wb') as file_handle:
+            np.savez(file_handle, **mlt_lc_files)
 
         cls.dtype = np.dtype([('id', np.int),
                              ('raDeg', np.float),
@@ -50,21 +70,42 @@ class FastStellar_lc_gen_case(unittest.TestCase):
         # write the catalog as a text file to be ingested with fileDBObject
         cls.txt_name = os.path.join(cls.scratchDir, "fast_stellar_lc_catalog.txt")
         with open(cls.txt_name, "w") as output_file:
-            sed_dex = rng.random_integers(0, len(list_of_seds)-1, size=n_stars)
-            lc_dex = rng.random_integers(0, len(list_of_lc)-1, size=n_stars)
-            mjd0 = rng.random_sample(n_stars)*10000.0+40000.0
-            raList = rng.random_sample(n_stars)*360.0
-            decList = -90.0 + rng.random_sample(n_stars)*120.0
-            magNormList = rng.random_sample(n_stars)*3.0+14.0
-            AvList = rng.random_sample(n_stars)*0.2+0.1
-            pxList = rng.random_sample(n_stars)*0.1
-            for ix in range(n_stars):
+            output_file.write('# a silly header\n')
+            sed_dex = rng.random_integers(0, len(list_of_seds)-1, size=cls.n_stars/2)
+            lc_dex = rng.random_integers(0, len(list_of_rrly_lc)-1, size=cls.n_stars/2)
+            mjd0 = rng.random_sample(cls.n_stars/2)*10000.0+40000.0
+            raList = rng.random_sample(cls.n_stars/2)*(cls.raRange[1]-cls.raRange[0])+cls.raRange[0]
+            decList = cls.decRange[0] + rng.random_sample(cls.n_stars/2)*(cls.decRange[1]-cls.decRange[1])
+            magNormList = rng.random_sample(cls.n_stars/2)*3.0+14.0
+            AvList = rng.random_sample(cls.n_stars/2)*0.2+0.1
+            pxList = rng.random_sample(cls.n_stars/2)*0.1
+            for ix in range(cls.n_stars/2):
                 varparams = {'varMethodName': 'applyRRly',
                              'pars': {'tStartMjd': mjd0[ix],
-                                      'filename': list_of_lc[lc_dex[ix]]}}
+                                      'filename': list_of_rrly_lc[lc_dex[ix]]}}
                 varparamstr = json.dumps(varparams)
                 output_file.write("%d;%lf;%lf;%lf;%lf;%lf;%lf;%s;%s;%lf;%lf\n"
                                   % (ix, raList[ix], decList[ix],
+                                     np.radians(raList[ix]),
+                                     np.radians(decList[ix]),
+                                     magNormList[ix], AvList[ix],
+                                     list_of_seds[sed_dex[ix]],
+                                     varparamstr,pxList[ix],
+                                     AvList[ix]/3.1))
+
+            sed_dex = rng.random_integers(0, len(list_of_seds)-1, size=cls.n_stars/2)
+            lc_dex = rng.random_integers(1, 2, size=cls.n_stars/2)
+            mjd0 = rng.random_sample(cls.n_stars/2)*10000.0+40000.0
+            raList = rng.random_sample(cls.n_stars/2)*(cls.raRange[1]-cls.raRange[0])+cls.raRange[0]
+            decList = cls.decRange[0] + rng.random_sample(cls.n_stars/2)*(cls.decRange[1]-cls.decRange[1])
+            magNormList = rng.random_sample(cls.n_stars/2)*3.0+14.0
+            AvList = rng.random_sample(cls.n_stars/2)*0.2+0.1
+            pxList = rng.random_sample(cls.n_stars/2)*0.1
+            for ix in range(cls.n_stars/2):
+                varparams = {'m':'MLT', 'p':{'lc':'lc_%d' % lc_dex[ix], 't0':rng.random_sample()*1000.0}}
+                varparamstr = json.dumps(varparams)
+                output_file.write("%d;%lf;%lf;%lf;%lf;%lf;%lf;%s;%s;%lf;%lf\n"
+                                  % (ix+cls.n_stars/2, raList[ix], decList[ix],
                                      np.radians(raList[ix]),
                                      np.radians(decList[ix]),
                                      magNormList[ix], AvList[ix],
@@ -88,19 +129,23 @@ class FastStellar_lc_gen_case(unittest.TestCase):
         sims_clean_up()
         if os.path.exists(cls.txt_name):
             os.unlink(cls.txt_name)
+        if os.path.exists(cls.mlt_lc_file_name):
+            os.unlink(cls.mlt_lc_file_name)
 
     def test_fast_stellar_lc_gen(self):
-        raRange = (78.0, 85.0)
-        decRange = (-69.0, -65.0)
+
         bandpass = ('r', 'g')
 
         lc_slow = StellarLightCurveGenerator(self.stellar_db, self.opsimDb)
-        ptngs = lc_slow.get_pointings(raRange, decRange, bandpass=bandpass)
+        lc_slow._lightCurveCatalogClass._mlt_lc_file = self.mlt_lc_file_name
+        ptngs = lc_slow.get_pointings((68.0, 95.0), (-69.0, -55.0), bandpass=bandpass)
         slow_lc, slow_truth = lc_slow.light_curves_from_pointings(ptngs, chunk_size=10)
-        self.assertGreater(len(slow_truth), 10)
+        self.assertEqual(len(slow_truth), self.n_stars)
+        self.assertEqual(len(slow_lc), self.n_stars)
 
         lc_fast = FastStellarLightCurveGenerator(self.stellar_db, self.opsimDb)
-        ptngs = lc_fast.get_pointings(raRange, decRange, bandpass=bandpass)
+        lc_fast._lightCurveCatalogClass._mlt_lc_file = self.mlt_lc_file_name
+        ptngs = lc_fast.get_pointings((68.0, 95.0), (-69.0, -55.0), bandpass=bandpass)
         fast_lc, fast_truth = lc_fast.light_curves_from_pointings(ptngs, chunk_size=10)
 
         self.assertEqual(len(fast_lc), len(slow_lc))
@@ -111,6 +156,8 @@ class FastStellar_lc_gen_case(unittest.TestCase):
             for bp in fast_lc[obj_id]:
                 self.assertEqual(len(fast_lc[obj_id][bp]), len(slow_lc[obj_id][bp]))
                 for data_key in fast_lc[obj_id][bp]:
+                    self.assertEqual(len(slow_lc[obj_id][bp][data_key]), len(fast_lc[obj_id][bp][data_key]))
+                    self.assertEqual(slow_lc[obj_id][bp][data_key].shape, slow_lc[obj_id][bp][data_key].shape)
                     self.assertLess(np.abs(fast_lc[obj_id][bp][data_key]-slow_lc[obj_id][bp][data_key]).max(),
                                     1.0e-10)
 

--- a/tests/testMLTflareModel.py
+++ b/tests/testMLTflareModel.py
@@ -286,6 +286,7 @@ class MLT_flare_test_case(unittest.TestCase):
                                                  'delta_lsst_u',
                                                  'delta_lsst_g'])
 
+            cat._mlt_lc_file = self.mlt_lc_name
             n_obj = 0
             for line in cat.iter_catalog():
                 n_obj += 1
@@ -376,6 +377,7 @@ class MLT_flare_test_case(unittest.TestCase):
                                                  'delta_lsst_u',
                                                  'delta_lsst_g'])
 
+            cat._mlt_lc_file = self.mlt_lc_name
             n_obj = 0
             for line in cat.iter_catalog():
                 n_obj += 1

--- a/tests/testMLTflareModel.py
+++ b/tests/testMLTflareModel.py
@@ -349,6 +349,104 @@ class MLT_flare_test_case(unittest.TestCase):
                     else:
                         self.assertEqual(delta_mag_vector[i_band][i_obj][i_time], 0.0)
 
+    def test_MLT_many_mjd_some_invalid(self):
+        """
+        This test will verify that applyMLTflaring responds properly when given
+        an array/vector of MJD values in the case where some stars are not
+        marked as valid MLT stars.
+        """
+        db = MLT_test_DB(database=self.db_name, driver='sqlite')
+        rng = np.random.RandomState(16)
+        mjd_arr = rng.random_sample(17)*3653.3+59580.0
+        objid = []
+        parallax = []
+        ebv = []
+        quiescent_u = []
+        quiescent_g = []
+        delta_u = []
+        delta_g = []
+        varparams = []
+        for mjd in mjd_arr:
+            obs = ObservationMetaData(mjd=mjd)
+            cat = FlaringCatalog(db, obs_metadata=obs,
+                                 column_outputs=['parallax', 'ebv',
+                                                 'quiescent_lsst_u',
+                                                 'quiescent_lsst_g',
+                                                 'varParamStr',
+                                                 'delta_lsst_u',
+                                                 'delta_lsst_g'])
+
+            n_obj = 0
+            for line in cat.iter_catalog():
+                n_obj += 1
+                objid.append(line[0])
+                parallax.append(line[3])
+                ebv.append(line[4])
+                quiescent_u.append(line[5])
+                quiescent_g.append(line[6])
+                varparams.append(line[7])
+                delta_u.append(line[8])
+                delta_g.append(line[9])
+
+        objid = np.array(objid)
+        parallax = np.array(parallax)
+        ebv = np.array(ebv)
+        quiescent_u = np.array(quiescent_u)
+        quiescent_g = np.array(quiescent_g)
+        delta_u = np.array(delta_u)
+        delta_g = np.array(delta_g)
+
+        self.assertEqual(len(parallax), n_obj*len(mjd_arr))
+        np.testing.assert_array_equal(objid, np.array([0,1,2,3]*len(mjd_arr)))
+
+        quiescent_mags = {}
+        quiescent_mags['u'] = quiescent_u
+        quiescent_mags['g'] = quiescent_g
+
+        params = {}
+        params['lc'] = []
+        params['t0'] = []
+        for ix in range(n_obj):
+            local_dict = json.loads(varparams[ix])
+            params['lc'].append(local_dict['p']['lc'])
+            params['t0'].append(local_dict['p']['t0'])
+        params['lc'] = np.array(params['lc'])
+        params['t0'] = np.array(params['t0'])
+
+        mlt_obj = MLTflaringMixin()
+        mlt_obj.photParams = PhotometricParameters()
+        mlt_obj.lsstBandpassDict = BandpassDict.loadTotalBandpassesFromFiles()
+        mlt_obj._mlt_lc_file = cat._mlt_lc_file
+        mlt_obj._actually_calculated_columns = ['delta_lsst_u', 'delta_lsst_g']
+        valid_dex = [] # applyMLT does not actually use valid_dex; it looks for non-None params['lc']
+        for ix in range(n_obj):
+            if ix not in (1,2):
+                params['lc'][ix] = None
+        delta_mag_vector = mlt_obj.applyMLTflaring(valid_dex, params, mjd_arr,
+                                                   parallax=parallax,
+                                                   ebv=ebv,
+                                                   quiescent_mags=quiescent_mags)
+        n_time = len(mjd_arr)
+        self.assertEqual(delta_mag_vector.shape, (6, n_obj, n_time))
+
+        for i_time, mjd in enumerate(mjd_arr):
+            for i_obj in range(n_obj):
+                if i_obj not in (1,2):
+                    for i_band in range(6):
+                        self.assertEqual(delta_mag_vector[i_band][i_obj][i_time], 0.0)
+                    continue
+
+                for i_band in range(6):
+                    if i_band==0:
+                        self.assertEqual(delta_mag_vector[i_band][i_obj][i_time],
+                                         delta_u[i_time*n_obj + i_obj])
+                    elif i_band==1:
+                        self.assertEqual(delta_mag_vector[i_band][i_obj][i_time],
+                                         delta_g[i_time*n_obj + i_obj])
+                    else:
+                        self.assertEqual(delta_mag_vector[i_band][i_obj][i_time], 0.0)
+
+
 
 class MLT_flare_mixed_with_none_model_test_case(unittest.TestCase):
     """

--- a/tests/testMLTflareModel.py
+++ b/tests/testMLTflareModel.py
@@ -367,6 +367,9 @@ class MLT_flare_mixed_with_none_model_test_case(unittest.TestCase):
         cls.mlt_lc_name = os.path.join(cls.scratch_dir,
                                        'test_mlt_mixed_with_none_lc_file.npz')
 
+        if os.path.exists(cls.mlt_lc_name):
+            os.unlink(cls.mlt_lc_name)
+
         lc_files = {}
         amp = 1.0e32
         lc_files['lc_1_time'] = np.arange(0.0, 3652.51, 0.1)
@@ -383,6 +386,9 @@ class MLT_flare_mixed_with_none_model_test_case(unittest.TestCase):
 
         # Create a database of stars using these light curves
         cls.db_name = os.path.join(cls.scratch_dir, 'test_mlt_mixed_with_none_db.db')
+
+        if os.path.exists(cls.db_name):
+            os.unlink(cls.db_name)
 
         conn = sqlite3.connect(cls.db_name)
         cursor = conn.cursor()

--- a/tests/testVariabilityManyTimes.py
+++ b/tests/testVariabilityManyTimes.py
@@ -51,6 +51,37 @@ class Variability_at_many_times_case(unittest.TestCase):
                     self.assertEqual(dmag_vector[i_band][i_star][i_time],
                                      dmag_test[i_band][i_star])
 
+    def test_Cepeheid_may(self):
+        rng = np.random.RandomState(8123)
+        params = {}
+        params['lcfile'] = ['cepheid_lc/classical_longPer_specfile',
+                            'cepheid_lc/classical_medPer_specfile',
+                            'cepheid_lc/classical_shortPer_specfile',
+                            'cepheid_lc/classical_shortPer_specfile',
+                            'cepheid_lc/popII_longPer_specfile',
+                            'cepheid_lc/popII_shortPer_specfile']
+
+        n_obj = len(params['lcfile'])
+
+        params['t0'] = rng.random_sample(n_obj)*1000.0+40000.0
+
+        mjd_arr = rng.random_sample(10)*3653.3 + 59580.0
+
+        n_time = len(mjd_arr)
+
+        valid_dexes = [np.arange(n_obj, dtype=int)]
+
+        dmag_vector = self.star_var.applyCepheid(valid_dexes, params, mjd_arr)
+        self.assertEqual(dmag_vector.shape, (6, n_obj, n_time))
+
+        for i_time, mjd in enumerate(mjd_arr):
+            dmag_test = self.star_var.applyCepheid(valid_dexes, params, mjd)
+            for i_band in range(6):
+                for i_obj in range(n_obj):
+                    self.assertEqual(dmag_test[i_band][i_obj],
+                                     dmag_vector[i_band][i_obj][i_time])
+
+
 
 class MemoryTestClass(lsst.utils.tests.MemoryTestCase):
     pass

--- a/tests/testVariabilityManyTimes.py
+++ b/tests/testVariabilityManyTimes.py
@@ -81,6 +81,27 @@ class Variability_at_many_times_case(unittest.TestCase):
                     self.assertEqual(dmag_test[i_band][i_obj],
                                      dmag_vector[i_band][i_obj][i_time])
 
+    def test_Eb_many(self):
+        rng = np.random.RandomState(814512)
+        params = {}
+        params['lcfile'] = ['eb_lc/EB.2294.inp',
+                            'eb_lc/EB.1540.inp',
+                            'eb_lc/EB.2801.inp']
+
+        n_obj = len(params['lcfile'])
+        params['t0'] = rng.random_sample(n_obj)*20000.0+30000.0
+        valid_dexes = [np.arange(n_obj, dtype=int)]
+        mjd_arr = rng.random_sample(19)*3653.3+59580.0
+        n_time = len(mjd_arr)
+        dmag_vector = self.star_var.applyEb(valid_dexes, params, mjd_arr)
+        self.assertEqual(dmag_vector.shape, (6, n_obj, n_time))
+
+        for i_time, mjd in enumerate(mjd_arr):
+            dmag_test = self.star_var.applyEb(valid_dexes, params, mjd)
+            for i_band in range(6):
+                for i_obj in range(n_obj):
+                    self.assertEqual(dmag_test[i_band][i_obj],
+                                     dmag_vector[i_band][i_obj][i_time])
 
 
 class MemoryTestClass(lsst.utils.tests.MemoryTestCase):

--- a/tests/testVariabilityManyTimes.py
+++ b/tests/testVariabilityManyTimes.py
@@ -103,6 +103,31 @@ class Variability_at_many_times_case(unittest.TestCase):
                     self.assertEqual(dmag_test[i_band][i_obj],
                                      dmag_vector[i_band][i_obj][i_time])
 
+    def test_MicroLens_many(self):
+        rng = np.random.RandomState(65123)
+        n_obj = 5
+        that = rng.random_sample(n_obj)*40.0+40.0
+        umin = rng.random_sample(n_obj)
+        mjDisplacement = rng.random_sample(n_obj)*50.0
+        params = {}
+        params['that'] = that
+        params['umin'] = umin
+        params['t0'] = mjDisplacement+51580.0
+
+        mjd_arr = rng.random_sample(17)*3653.3+59580.0
+        n_time = len(mjd_arr)
+        valid_dexes = [np.arange(n_obj, dtype=int)]
+        dmag_vector = self.star_var.applyMicrolens(valid_dexes, params, mjd_arr)
+        self.assertEqual(dmag_vector.shape, (6, n_obj, n_time))
+
+        for i_time, mjd in enumerate(mjd_arr):
+            dmag_test = self.star_var.applyMicrolens(valid_dexes, params, mjd)
+            self.assertEqual(dmag_test.shape, (6, n_obj))
+            for i_band in range(6):
+                for i_obj in range(n_obj):
+                    self.assertEqual(dmag_test[i_band][i_obj],
+                                     dmag_vector[i_band][i_obj][i_time])
+
 
 class MemoryTestClass(lsst.utils.tests.MemoryTestCase):
     pass

--- a/tests/testVariabilityManyTimes.py
+++ b/tests/testVariabilityManyTimes.py
@@ -29,7 +29,7 @@ class Variability_at_many_times_case(unittest.TestCase):
 
         n_obj = len(params['filename'])
 
-        params['tStartMjd'] = rng.random_sample(4)*1000.0+40000.0
+        params['tStartMjd'] = rng.random_sample(n_obj)*1000.0+40000.0
 
         mjd_arr = rng.random_sample(10)*3653.3+59580.0
 

--- a/tests/testVariabilityManyTimes.py
+++ b/tests/testVariabilityManyTimes.py
@@ -257,6 +257,7 @@ class Variability_at_many_times_case(unittest.TestCase):
             self.assertEqual(dmag_test.shape, (6, n_obj))
             for i_band in range(6):
                 for i_obj in range(n_obj):
+                    self.assertTrue(isinstance(dmag_test[i_band][i_obj], numbers.Number))
                     self.assertEqual(dmag_test[i_band][i_obj],
                                      dmag_vector[i_band][i_obj][i_time])
 

--- a/tests/testVariabilityManyTimes.py
+++ b/tests/testVariabilityManyTimes.py
@@ -1,0 +1,60 @@
+import unittest
+import lsst.utils.tests
+import numpy as np
+
+from lsst.sims.catUtils.mixins import StellarVariabilityModels
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+class Variability_at_many_times_case(unittest.TestCase):
+    """
+    This test case will verify that all of the variability
+    models in CatSim deal correctly with receiving a vector
+    of time values.
+    """
+
+    def setUp(self):
+        self.star_var = StellarVariabilityModels()
+        self.star_var.initializeVariability()
+
+    def test_RRLy_many(self):
+        rng = np.random.RandomState(42)
+        params = {}
+        params['filename'] = ['rrly_lc/RRc/959802_per.txt',
+                              'rrly_lc/RRc/1078860_per.txt',
+                              'rrly_lc/RRab/98874_per.txt',
+                              'rrly_lc/RRab/3879827_per.txt']
+
+        n_obj = len(params['filename'])
+
+        params['tStartMjd'] = rng.random_sample(4)*1000.0+40000.0
+
+        mjd_arr = rng.random_sample(10)*3653.3+59580.0
+
+        n_time = len(mjd_arr)
+
+        dmag_vector = self.star_var.applyRRly([np.arange(n_obj, dtype=int)],
+                                              params,
+                                              mjd_arr)
+
+        self.assertEqual(dmag_vector.shape, (6, n_obj, n_time))
+
+        for i_time, mjd in enumerate(mjd_arr):
+            dmag_test = self.star_var.applyRRly([np.arange(n_obj,dtype=int)],
+                                                params,
+                                                mjd)
+
+            for i_star in range(n_obj):
+                for i_band in range(6):
+                    self.assertEqual(dmag_vector[i_band][i_star][i_time],
+                                     dmag_test[i_band][i_star])
+
+
+class MemoryTestClass(lsst.utils.tests.MemoryTestCase):
+    pass
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/testVariabilityManyTimes.py
+++ b/tests/testVariabilityManyTimes.py
@@ -83,6 +83,8 @@ class StellarVariability_at_many_times_case(unittest.TestCase):
     of time values.
     """
 
+    longMessage = True
+
     def setUp(self):
         self.star_var = StellarVariabilityModels()
         self.star_var.initializeVariability()
@@ -119,7 +121,50 @@ class StellarVariability_at_many_times_case(unittest.TestCase):
                     self.assertEqual(dmag_vector[i_band][i_star][i_time],
                                      dmag_test[i_band][i_star])
 
-    def test_Cepeheid_may(self):
+    def test_RRLy_many_some_invalid(self):
+        """
+        Test that the correct thing happens when some of the objects
+        do not use the variability model.
+        """
+        rng = np.random.RandomState(42)
+        params = {}
+        params['filename'] = ['rrly_lc/RRc/959802_per.txt',
+                              'rrly_lc/RRc/1078860_per.txt',
+                              'rrly_lc/RRab/98874_per.txt',
+                              'rrly_lc/RRab/3879827_per.txt']
+
+        n_obj = len(params['filename'])
+
+        params['tStartMjd'] = rng.random_sample(n_obj)*1000.0+40000.0
+
+        mjd_arr = rng.random_sample(10)*3653.3+59580.0
+
+        n_time = len(mjd_arr)
+        valid_dexes = [np.array([1,3])]
+
+        dmag_vector = self.star_var.applyRRly(valid_dexes,
+                                              params,
+                                              mjd_arr)
+
+        self.assertEqual(dmag_vector.shape, (6, n_obj, n_time))
+
+        for i_time, mjd in enumerate(mjd_arr):
+            dmag_test = self.star_var.applyRRly(valid_dexes,
+                                                params,
+                                                mjd)
+
+            for i_star in range(n_obj):
+                if i_star in (0, 2):
+                    for i_band in range(6):
+                        self.assertEqual(dmag_test[i_band][i_star], 0.0,
+                                         msg='failed on obj %d; band %d; time %d' % (i_star, i_band, i_time))
+                for i_band in range(6):
+                    self.assertEqual(dmag_vector[i_band][i_star][i_time],
+                                     dmag_test[i_band][i_star],
+                                     msg='failed on obj %d; band %d; time %d' % (i_star, i_band, i_time))
+
+
+    def test_Cepeheid_many(self):
         rng = np.random.RandomState(8123)
         params = {}
         params['lcfile'] = ['cepheid_lc/classical_longPer_specfile',
@@ -149,6 +194,43 @@ class StellarVariability_at_many_times_case(unittest.TestCase):
                     self.assertEqual(dmag_test[i_band][i_obj],
                                      dmag_vector[i_band][i_obj][i_time])
 
+    def test_Cepeheid_many_some_invalid(self):
+        """
+        Test that the correct thing happens when some of the objects
+        do not use the variability model.
+        """
+        rng = np.random.RandomState(8123)
+        params = {}
+        params['lcfile'] = ['cepheid_lc/classical_longPer_specfile',
+                            'cepheid_lc/classical_medPer_specfile',
+                            'cepheid_lc/classical_shortPer_specfile',
+                            'cepheid_lc/classical_shortPer_specfile',
+                            'cepheid_lc/popII_longPer_specfile',
+                            'cepheid_lc/popII_shortPer_specfile']
+
+        n_obj = len(params['lcfile'])
+
+        params['t0'] = rng.random_sample(n_obj)*1000.0+40000.0
+
+        mjd_arr = rng.random_sample(10)*3653.3 + 59580.0
+
+        n_time = len(mjd_arr)
+
+        valid_dexes = [np.array([1,3])]
+
+        dmag_vector = self.star_var.applyCepheid(valid_dexes, params, mjd_arr)
+        self.assertEqual(dmag_vector.shape, (6, n_obj, n_time))
+
+        for i_time, mjd in enumerate(mjd_arr):
+            dmag_test = self.star_var.applyCepheid(valid_dexes, params, mjd)
+            for i_band in range(6):
+                for i_obj in range(n_obj):
+                    if i_obj not in (1, 3):
+                        self.assertEqual(dmag_test[i_band][i_obj], 0.0)
+                    self.assertEqual(dmag_test[i_band][i_obj],
+                                     dmag_vector[i_band][i_obj][i_time])
+
+
     def test_Eb_many(self):
         rng = np.random.RandomState(814512)
         params = {}
@@ -170,6 +252,35 @@ class StellarVariability_at_many_times_case(unittest.TestCase):
                 for i_obj in range(n_obj):
                     self.assertEqual(dmag_test[i_band][i_obj],
                                      dmag_vector[i_band][i_obj][i_time])
+
+    def test_Eb_many_some_invalid(self):
+        """
+        Test that the correct thing happens when some of the objects
+        do not use the variability model.
+        """
+        rng = np.random.RandomState(814512)
+        params = {}
+        params['lcfile'] = ['eb_lc/EB.2294.inp',
+                            'eb_lc/EB.1540.inp',
+                            'eb_lc/EB.2801.inp']
+
+        n_obj = len(params['lcfile'])
+        params['t0'] = rng.random_sample(n_obj)*20000.0+30000.0
+        valid_dexes = [np.array([0,2])]
+        mjd_arr = rng.random_sample(19)*3653.3+59580.0
+        n_time = len(mjd_arr)
+        dmag_vector = self.star_var.applyEb(valid_dexes, params, mjd_arr)
+        self.assertEqual(dmag_vector.shape, (6, n_obj, n_time))
+
+        for i_time, mjd in enumerate(mjd_arr):
+            dmag_test = self.star_var.applyEb(valid_dexes, params, mjd)
+            for i_band in range(6):
+                for i_obj in range(n_obj):
+                    if i_obj not in (0, 2):
+                        self.assertEqual(dmag_test[i_band][i_obj], 0.0)
+                    self.assertEqual(dmag_test[i_band][i_obj],
+                                     dmag_vector[i_band][i_obj][i_time])
+
 
     def test_MicroLens_many(self):
         rng = np.random.RandomState(65123)
@@ -195,6 +306,38 @@ class StellarVariability_at_many_times_case(unittest.TestCase):
                 for i_obj in range(n_obj):
                     self.assertEqual(dmag_test[i_band][i_obj],
                                      dmag_vector[i_band][i_obj][i_time])
+
+    def test_MicroLens_many_some_invalid(self):
+        """
+        Test that the correct thing happens when some of the objects
+        do not use the variability model.
+        """
+        rng = np.random.RandomState(65123)
+        n_obj = 5
+        that = rng.random_sample(n_obj)*40.0+40.0
+        umin = rng.random_sample(n_obj)
+        mjDisplacement = rng.random_sample(n_obj)*50.0
+        params = {}
+        params['that'] = that
+        params['umin'] = umin
+        params['t0'] = mjDisplacement+51580.0
+
+        mjd_arr = rng.random_sample(17)*3653.3+59580.0
+        n_time = len(mjd_arr)
+        valid_dexes = [np.array([1,3])]
+        dmag_vector = self.star_var.applyMicrolens(valid_dexes, params, mjd_arr)
+        self.assertEqual(dmag_vector.shape, (6, n_obj, n_time))
+
+        for i_time, mjd in enumerate(mjd_arr):
+            dmag_test = self.star_var.applyMicrolens(valid_dexes, params, mjd)
+            self.assertEqual(dmag_test.shape, (6, n_obj))
+            for i_band in range(6):
+                for i_obj in range(n_obj):
+                    if i_obj not in (1,3):
+                        self.assertEqual(dmag_test[i_band][i_obj], 0.0)
+                    self.assertEqual(dmag_test[i_band][i_obj],
+                                     dmag_vector[i_band][i_obj][i_time])
+
 
     def test_Amcvn_many(self):
         rng = np.random.RandomState(71242)
@@ -236,6 +379,53 @@ class StellarVariability_at_many_times_case(unittest.TestCase):
                     self.assertEqual(dmag_test[i_band][i_obj],
                                      dmag_vector[i_band][i_obj][i_time])
 
+    def test_Amcvn_many_some_invalid(self):
+        """
+        Test that the correct thing happens when some of the objects
+        do not use the variability model.
+        """
+        rng = np.random.RandomState(71242)
+        n_obj = 20
+        doesBurst = rng.randint(0, 2, size=n_obj)
+        burst_freq = rng.randint(10, 150, size=n_obj)
+        burst_scale = np.array([1500.0]*n_obj)
+        amp_burst = rng.random_sample(n_obj)*8.0
+        color_excess_during_burst = rng.random_sample(n_obj)*0.2-0.4
+        amplitude = rng.random_sample(n_obj)*0.2
+        period = rng.random_sample(n_obj)*200.0
+        mjDisplacement = rng.random_sample(n_obj)*500.0
+        params = {}
+        params['does_burst'] = doesBurst
+        params['burst_freq'] = burst_freq
+        params['burst_scale'] = burst_scale
+        params['amp_burst'] = amp_burst
+        params['color_excess_during_burst'] = color_excess_during_burst
+        params['amplitude'] = amplitude
+        params['period'] = period
+        params['t0'] = 51500.0-mjDisplacement
+
+        mjd_arr = rng.random_sample(100)*3653.3+59580.0
+        n_time = len(mjd_arr)
+
+        valid_dexes = [np.array([1,5,6])]
+
+        dmag_vector = self.star_var.applyAmcvn(valid_dexes, params, mjd_arr)
+
+        self.assertEqual(dmag_vector.shape, (6, n_obj, n_time))
+        for i_time, mjd in enumerate(mjd_arr):
+            dmag_test = self.star_var.applyAmcvn(valid_dexes, params, mjd)
+            self.assertEqual(dmag_test.shape, (6, n_obj))
+            dmag_old = applyAmcvn_original(valid_dexes, params,mjd)
+            for i_obj in range(n_obj):
+                for i_band in range(6):
+                    if i_obj not in(1,5,6):
+                        self.assertEqual(dmag_test[i_band][i_obj], 0.0)
+                    self.assertEqual(dmag_test[i_band][i_obj],
+                                     dmag_old[i_band][i_obj])
+                    self.assertEqual(dmag_test[i_band][i_obj],
+                                     dmag_vector[i_band][i_obj][i_time])
+
+
     def test_BHMicrolens_many(self):
         rng = np.random.RandomState(5132)
         params = {}
@@ -258,6 +448,38 @@ class StellarVariability_at_many_times_case(unittest.TestCase):
             self.assertEqual(dmag_test.shape, (6, n_obj))
             for i_band in range(6):
                 for i_obj in range(n_obj):
+                    self.assertTrue(isinstance(dmag_test[i_band][i_obj], numbers.Number))
+                    self.assertEqual(dmag_test[i_band][i_obj],
+                                     dmag_vector[i_band][i_obj][i_time])
+
+    def test_BHMicrolens_many_some_invalid(self):
+        """
+        Test that the correct thing happens when some of the objects
+        do not use the variability model.
+        """
+        rng = np.random.RandomState(5132)
+        params = {}
+        params['filename'] = ['microlens/bh_binary_source/lc_14_25_75_8000_0_0.05_316',
+                              'microlens/bh_binary_source/lc_14_25_4000_8000_0_phi1.09_0.005_100',
+                              'microlens/bh_binary_source/lc_14_25_75_8000_0_tets2.09_0.005_316']
+
+        n_obj = len(params['filename'])
+        params['t0'] = rng.random_sample(n_obj)*10.0+59580.0
+
+        mjd_arr = rng.random_sample(12)*4.0+59590.0
+        n_time = len(mjd_arr)
+        valid_dexes = [np.array([1])]
+
+        dmag_vector = self.star_var.applyBHMicrolens(valid_dexes, params, mjd_arr)
+        self.assertEqual(dmag_vector.shape, (6, n_obj, n_time))
+
+        for i_time, mjd in enumerate(mjd_arr):
+            dmag_test = self.star_var.applyBHMicrolens(valid_dexes, params, mjd)
+            self.assertEqual(dmag_test.shape, (6, n_obj))
+            for i_band in range(6):
+                for i_obj in range(n_obj):
+                    if i_obj != 1:
+                        self.assertEqual(dmag_test[i_band][i_obj], 0.0)
                     self.assertTrue(isinstance(dmag_test[i_band][i_obj], numbers.Number))
                     self.assertEqual(dmag_test[i_band][i_obj],
                                      dmag_vector[i_band][i_obj][i_time])
@@ -299,6 +521,43 @@ class AgnVariability_at_many_times_case(unittest.TestCase):
             self.assertEqual(dmag_test.shape, (6, n_obj))
             for i_band in range(6):
                 for i_obj in range(n_obj):
+                    self.assertEqual(dmag_vector[i_band][i_obj][i_time],
+                                     dmag_test[i_band][i_obj],
+                                     msg='failed on band %d obj %d time %d' % (i_band, i_obj, i_time))
+
+    def test_agn_many_some_invalid(self):
+        """
+        Test that the correct thing happens when some of the objects
+        do not use the variability model.
+        """
+        agn_model = ExtraGalacticVariabilityModels()
+        rng = np.random.RandomState(7153)
+        params  = {}
+        n_obj = 5
+        params['agn_tau'] = rng.random_sample(n_obj)*100.0+100.0
+        params['agn_sfu'] = rng.random_sample(n_obj)*2.0
+        params['agn_sfg'] = rng.random_sample(n_obj)*2.0
+        params['agn_sfr'] = rng.random_sample(n_obj)*2.0
+        params['agn_sfi'] = rng.random_sample(n_obj)*2.0
+        params['agn_sfz'] = rng.random_sample(n_obj)*2.0
+        params['agn_sfy'] = rng.random_sample(n_obj)*2.0
+        params['t0_mjd'] = 48000.0+rng.random_sample(n_obj)*5.0
+        params['seed'] = rng.randint(0, 20000, size=n_obj)
+
+        mjd_arr = np.sort(rng.random_sample(6)*3653.3+59580.0)
+        n_time = len(mjd_arr)
+
+        valid_dexes = [np.array([1,2,4])]
+        dmag_vector = agn_model.applyAgn(valid_dexes, params, mjd_arr)
+        self.assertEqual(dmag_vector.shape, (6, n_obj,n_time))
+
+        for i_time, mjd in enumerate(mjd_arr):
+            dmag_test = agn_model.applyAgn(valid_dexes, params, mjd)
+            self.assertEqual(dmag_test.shape, (6, n_obj))
+            for i_band in range(6):
+                for i_obj in range(n_obj):
+                    if i_obj not in (1,2,4):
+                        self.assertEqual(dmag_test[i_band][i_obj], 0.0)
                     self.assertEqual(dmag_vector[i_band][i_obj][i_time],
                                      dmag_test[i_band][i_obj],
                                      msg='failed on band %d obj %d time %d' % (i_band, i_obj, i_time))

--- a/tests/testVariabilityManyTimes.py
+++ b/tests/testVariabilityManyTimes.py
@@ -235,6 +235,31 @@ class Variability_at_many_times_case(unittest.TestCase):
                     self.assertEqual(dmag_test[i_band][i_obj],
                                      dmag_vector[i_band][i_obj][i_time])
 
+    def test_BHMicrolens_many(self):
+        rng = np.random.RandomState(5132)
+        params = {}
+        params['filename'] = ['microlens/bh_binary_source/lc_14_25_75_8000_0_0.05_316',
+                              'microlens/bh_binary_source/lc_14_25_4000_8000_0_phi1.09_0.005_100',
+                              'microlens/bh_binary_source/lc_14_25_75_8000_0_tets2.09_0.005_316']
+
+        n_obj = len(params['filename'])
+        params['t0'] = rng.random_sample(n_obj)*10.0+59580.0
+
+        mjd_arr = rng.random_sample(12)*4.0+59590.0
+        n_time = len(mjd_arr)
+        valid_dexes = [np.arange(n_obj, dtype=int)]
+
+        dmag_vector = self.star_var.applyBHMicrolens(valid_dexes, params, mjd_arr)
+        self.assertEqual(dmag_vector.shape, (6, n_obj, n_time))
+
+        for i_time, mjd in enumerate(mjd_arr):
+            dmag_test = self.star_var.applyBHMicrolens(valid_dexes, params, mjd)
+            self.assertEqual(dmag_test.shape, (6, n_obj))
+            for i_band in range(6):
+                for i_obj in range(n_obj):
+                    self.assertEqual(dmag_test[i_band][i_obj],
+                                     dmag_vector[i_band][i_obj][i_time])
+
 
 class MemoryTestClass(lsst.utils.tests.MemoryTestCase):
     pass

--- a/tests/testVariabilityManyTimes.py
+++ b/tests/testVariabilityManyTimes.py
@@ -294,8 +294,6 @@ class AgnVariability_at_many_times_case(unittest.TestCase):
         dmag_vector = agn_model.applyAgn(valid_dexes, params, mjd_arr)
         self.assertEqual(dmag_vector.shape, (6, n_obj,n_time))
 
-        print 'starting one-at-a-time'
-        print 'max time ',mjd_arr.max()
         for i_time, mjd in enumerate(mjd_arr):
             dmag_test = agn_model.applyAgn(valid_dexes, params, mjd)
             self.assertEqual(dmag_test.shape, (6, n_obj))

--- a/tests/testVariabilityManyTimes.py
+++ b/tests/testVariabilityManyTimes.py
@@ -23,7 +23,7 @@ def applyAmcvn_original(valid_dexes, params, expmjd_in):
     if len(params) == 0:
         return np.array([[],[],[],[],[],[]])
 
-    n_obj = len(params[params.keys()[0]])
+    n_obj = len(params[list(params.keys())[0]])
 
     maxyears = 10.
     dMag = np.zeros((6, n_obj))

--- a/tests/testVariabilityMixins.py
+++ b/tests/testVariabilityMixins.py
@@ -42,7 +42,7 @@ def makeRRlyTable(size=100, **kwargs):
                      (varsimobjid int, variability text, sedfilename text, parallax real, ebv real)''')
         conn.commit()
     except:
-        raise RuntimeError("Error creating database.")
+        return
 
     rng = np.random.RandomState(32)
     mjDisplacement = (rng.random_sample(size)-50.0)*50.0
@@ -79,7 +79,7 @@ def makeCepheidTable(size=100, **kwargs):
                      (varsimobjid int, variability text, sedfilename text, parallax real, ebv real)''')
         conn.commit()
     except:
-        raise RuntimeError("Error creating database.")
+        return
 
     rng = np.random.RandomState(32)
     periods = rng.random_sample(size)*50.0
@@ -112,7 +112,7 @@ def makeEbTable(size=100, **kwargs):
                      (varsimobjid int, variability text, sedfilename text, parallax real, ebv real)''')
         conn.commit()
     except:
-        raise RuntimeError("Error creating database.")
+        return
 
     rng = np.random.RandomState(32)
     periods = rng.random_sample(size)*50.0
@@ -147,7 +147,7 @@ def makeMicrolensingTable(size=100, **kwargs):
                      (varsimobjid int, variability text, sedfilename text, parallax real, ebv real)''')
         conn.commit()
     except:
-        raise RuntimeError("Error creating database.")
+        return
 
     rng = np.random.RandomState(32)
     that = rng.random_sample(size)*40.0+40.0
@@ -186,7 +186,7 @@ def makeBHMicrolensingTable(size=100, **kwargs):
                      (varsimobjid int, variability text, sedfilename text, parallax real, ebv real)''')
         conn.commit()
     except:
-        raise RuntimeError("Error creating database.")
+        return
 
     rng = np.random.RandomState(32)
     mjDisplacement = rng.random_sample(size)*5.0*365.25
@@ -218,7 +218,7 @@ def makeAmcvnTable(size=100, **kwargs):
                      (varsimobjid int, variability text, sedfilename text, parallax real, ebv real)''')
         conn.commit()
     except:
-        raise RuntimeError("Error creating database.")
+        return
 
     rng = np.random.RandomState(32)
     doesBurst = rng.randint(0, 2, size=size)
@@ -266,7 +266,7 @@ def makeAgnTable(size=100, **kwargs):
                       sedFilenameBulge text, sedFilenameDisk text, sedFilenameAgn text)''')
         conn.commit()
     except:
-        raise RuntimeError("Error creating database.")
+        return
 
     rng = np.random.RandomState(32)
     agn_tau = rng.random_sample(size)*100.0+100.0
@@ -323,7 +323,7 @@ def makeHybridTable(size=100, **kwargs):
                      (varsimobjid int, variability text, sedfilename text, parallax real, ebv real)''')
         conn.commit()
     except:
-        raise RuntimeError("Error creating database.")
+        return
 
     rng = np.random.RandomState(32)
     periods = rng.random_sample(size)*50.0


### PR DESCRIPTION
This pull request should implement a faster version of the LightCurveGenerator for cases where the variability model is simply

quiescent_mag + delta_mag(t)

where quiescent_mag does not vary as a function of time (this is in contrast to the SNIa variability model, which is a full spectro-temporal variability model in which, at each time step, a new supernova SED must be created and integrated over the LSST bandpasses).

If this branch, as it exists, still is not fast enough for alertsim, we can iterate further before closing and merging this pull request.