### PR TITLE
Sim 2408/nfs bug

### DIFF
--- a/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
+++ b/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
@@ -661,6 +661,8 @@ class MLTflaringMixin(Variability):
             _MLT_LC_NPZ = numpy.load(self._mlt_lc_file)
             sims_clean_up.targets.append(_MLT_LC_NPZ)
             _MLT_LC_NPZ_NAME = self._mlt_lc_file
+            _MLT_LC_TIME_CACHE = {}
+            _MLT_LC_FLUX_CACHE = {}
 
         if not hasattr(self, '_mlt_dust_lookup'):
             # Construct a look-up table to determine the factor

--- a/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
+++ b/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
@@ -82,11 +82,17 @@ __all__ = ["Variability", "VariabilityStars", "VariabilityGalaxies",
            "reset_agn_lc_cache", "StellarVariabilityModels",
            "ExtraGalacticVariabilityModels", "MLTflaringMixin"]
 
-_AGN_LC_CACHE = {} # a global cache of agn light curve calculations
-_MLT_LC_NPZ = None
-_MLT_LC_NPZ_NAME = None
-_MLT_LC_TIME_CACHE = {}
-_MLT_LC_FLUX_CACHE = {}
+_AGN_LC_CACHE = {}  # a global cache of agn light curve calculations
+
+_MLT_LC_NPZ = None  # this will be loaded from a .npz file
+                    # (.npz files are the result of numpy.savez())
+
+_MLT_LC_NPZ_NAME = None  # the name of the .npz file to beloaded
+
+_MLT_LC_TIME_CACHE = {}  # a dict for storing loaded time grids
+
+_MLT_LC_FLUX_CACHE = {}  # a dict for storing loaded flux grids
+
 
 def reset_agn_lc_cache():
     """

--- a/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
+++ b/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
@@ -72,6 +72,7 @@ import json as json
 from lsst.utils import getPackageDir
 from lsst.sims.catalogs.decorators import register_method, compound
 from lsst.sims.photUtils import Sed, BandpassDict
+from lsst.sims.utils.CodeUtilities import sims_clean_up
 from scipy.interpolate import InterpolatedUnivariateSpline
 from scipy.interpolate import UnivariateSpline
 from scipy.interpolate import interp1d
@@ -652,6 +653,7 @@ class MLTflaringMixin(Variability):
                                     + "to get the data")
 
             _MLT_LC_NPZ = numpy.load(self._mlt_lc_file)
+            sims_clean_up.targets.append(_MLT_LC_NPZ)
             _MLT_LC_NPZ_NAME = self._mlt_lc_file
 
         if not hasattr(self, '_mlt_dust_lookup'):

--- a/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
+++ b/python/lsst/sims/catUtils/mixins/VariabilityMixin.py
@@ -641,7 +641,7 @@ class MLTflaringMixin(Variability):
                                "knowledge of the effective area of the LSST "
                                "mirror.")
 
-        if _MLT_LC_NPZ is None or _MLT_LC_NPZ_NAME != self._mlt_lc_file:
+        if _MLT_LC_NPZ is None or _MLT_LC_NPZ_NAME != self._mlt_lc_file or _MLT_LC_NPZ.fid is None:
             if not os.path.exists(self._mlt_lc_file):
                 catutils_scripts = os.path.join(getPackageDir('sims_catUtils'), 'support_scripts')
                 raise RuntimeError("The MLT flaring light curve file:\n"

--- a/tests/testMLTflareModel.py
+++ b/tests/testMLTflareModel.py
@@ -450,6 +450,38 @@ class MLT_flare_test_case(unittest.TestCase):
                     else:
                         self.assertEqual(delta_mag_vector[i_band][i_obj][i_time], 0.0)
 
+    def test_mlt_clean_up(self):
+        """
+        Test that the MLT cache is correctly loaded after sims_clean_up is
+        called.
+        """
+        db = MLT_test_DB(database=self.db_name, driver='sqlite')
+        obs = ObservationMetaData(mjd=60000.0)
+        cat = FlaringCatalog(db, obs_metadata=obs)
+        cat_name_1 = os.path.join(self.scratch_dir,'mlt_clean_test_cat_1.txt')
+        cat.write_catalog(cat_name_1)
+        sims_clean_up()
+
+        # re-generate the same catalog and verify that its
+        # contents are unchanged
+        db = MLT_test_DB(database=self.db_name, driver='sqlite')
+        obs = ObservationMetaData(mjd=60000.0)
+        cat = FlaringCatalog(db, obs_metadata=obs)
+        cat_name_2 = os.path.join(self.scratch_dir,'mlt_clean_test_cat_2.txt')
+        cat.write_catalog(cat_name_2)
+        with open(cat_name_1, 'r') as in_file_1:
+            lines_1 = in_file_1.readlines()
+        with open(cat_name_2, 'r') as in_file_2:
+            lines_2 = in_file_2.readlines()
+        self.assertGreater(len(lines_1), 1)
+        self.assertEqual(len(lines_1), len(lines_2))
+        for line in lines_1:
+            self.assertIn(line, lines_2)
+
+        if os.path.exists(cat_name_1):
+            os.unlink(cat_name_1)
+        if os.path.exists(cat_name_2):
+            os.unlink(cat_name_2)
 
 
 class MLT_flare_mixed_with_none_model_test_case(unittest.TestCase):

--- a/tests/testMLTflareModel.py
+++ b/tests/testMLTflareModel.py
@@ -16,6 +16,7 @@ from lsst.sims.utils import ObservationMetaData
 from lsst.sims.photUtils import SedList, BandpassDict, Sed
 from lsst.sims.utils import radiansFromArcsec
 from lsst.sims.photUtils import PhotometricParameters
+from lsst.sims.utils.CodeUtilities import sims_clean_up
 
 def setup_module(module):
     lsst.utils.tests.init()
@@ -112,6 +113,7 @@ class MLT_flare_test_case(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        sims_clean_up()
         if os.path.exists(cls.mlt_lc_name):
             os.unlink(cls.mlt_lc_name)
 
@@ -525,6 +527,7 @@ class MLT_flare_mixed_with_none_model_test_case(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        sims_clean_up()
         if os.path.exists(cls.mlt_lc_name):
             os.unlink(cls.mlt_lc_name)
 
@@ -777,6 +780,7 @@ class MLT_flare_mixed_with_dummy_model_test_case(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        sims_clean_up()
         if os.path.exists(cls.mlt_lc_name):
             os.unlink(cls.mlt_lc_name)
 

--- a/tests/testMLTflareModel.py
+++ b/tests/testMLTflareModel.py
@@ -458,6 +458,7 @@ class MLT_flare_test_case(unittest.TestCase):
         db = MLT_test_DB(database=self.db_name, driver='sqlite')
         obs = ObservationMetaData(mjd=60000.0)
         cat = FlaringCatalog(db, obs_metadata=obs)
+        cat._mlt_lc_file = self.mlt_lc_name
         cat_name_1 = os.path.join(self.scratch_dir,'mlt_clean_test_cat_1.txt')
         cat.write_catalog(cat_name_1)
         sims_clean_up()
@@ -467,6 +468,7 @@ class MLT_flare_test_case(unittest.TestCase):
         db = MLT_test_DB(database=self.db_name, driver='sqlite')
         obs = ObservationMetaData(mjd=60000.0)
         cat = FlaringCatalog(db, obs_metadata=obs)
+        cat._mlt_lc_file = self.mlt_lc_name
         cat_name_2 = os.path.join(self.scratch_dir,'mlt_clean_test_cat_2.txt')
         cat.write_catalog(cat_name_2)
         with open(cat_name_1, 'r') as in_file_1:

--- a/tests/testPhoSimAstrometry.py
+++ b/tests/testPhoSimAstrometry.py
@@ -14,7 +14,7 @@ from lsst.sims.catUtils.utils import testStarsDBObj, testGalaxyDiskDBObj
 from lsst.sims.catUtils.mixins import PhoSimAstrometryBase
 from lsst.sims.catUtils.mixins import PhoSimAstrometryStars
 from lsst.sims.catUtils.mixins import PhoSimAstrometryGalaxies
-
+from lsst.sims.utils.CodeUtilities import sims_clean_up
 
 def setup_module(module):
     lsst.utils.tests.init()
@@ -56,6 +56,7 @@ class PhoSimAstrometryTestCase(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        sims_clean_up()
         if os.path.exists(cls.db_name):
             os.unlink(cls.db_name)
 


### PR DESCRIPTION
Some unit tests were failing on NFS systems because of open database connections left dangling after the tests were run.  This pull request modifies those tests to explicitly call `sims_clean_up()`, closing those connections before running the standard LSST memory leak tests.