### PR TITLE
SIM-2425: Work with pytest-xdist

### DIFF
--- a/examples/baseValidation/utils.py
+++ b/examples/baseValidation/utils.py
@@ -129,7 +129,7 @@ def get_TotalSDSSMags(result, bandpasses=('u','g','r','i','z')):
     datadir = os.environ.get("SIMS_SED_LIBRARY_DIR")
     tpath = os.getenv('SDSS_THROUGHPUTS')
     bands = {"u":None, "g":None, "r":None, "i":None, "z":None}
-    for k in bands.keys():
+    for k in bands:
         bands[k] = Bandpass()
         bands[k].readThroughput(os.path.join(tpath, "sdss_%s.dat"%k))
     # Set up phi, the wavelength-normalized system response for each filter,
@@ -155,7 +155,7 @@ def get_TotalSDSSMags(result, bandpasses=('u','g','r','i','z')):
     imsimband = Bandpass()
     imsimband.imsimBandpass()
     sedDict = {}
-    retMags = dict([(k, []) for k in bands.keys()])
+    retMags = dict([(k, []) for k in bands])
     a_int = None
     b_int = None
     tmpwavelen = None
@@ -206,7 +206,7 @@ def get_TotalMags(result, bandpasses=('u','g','r','i','z','y')):
     datadir = os.environ.get("SIMS_SED_LIBRARY_DIR")
     tpath = os.getenv('LSST_THROUGHPUTS_DEFAULT')
     bands = {"u":None, "g":None, "r":None, "i":None, "z":None, "y":None}
-    for k in bands.keys():
+    for k in bands:
         bands[k] = Bandpass()
         bands[k].readThroughput(os.path.join(tpath, "total_%s.dat"%k))
     # Set up phi, the wavelength-normalized system response for each filter,
@@ -232,7 +232,7 @@ def get_TotalMags(result, bandpasses=('u','g','r','i','z','y')):
     imsimband = Bandpass()
     imsimband.imsimBandpass()
     sedDict = {}
-    retMags = dict([(k, []) for k in bands.keys()])
+    retMags = dict([(k, []) for k in bands])
     a_int = None
     b_int = None
     tmpwavelen = None
@@ -435,7 +435,7 @@ def loadFile(file, colTypeMap, baseCatalog=None):
     colnames = hdr.rstrip().split(",")
     if baseCatalog:
         for name in colnames:
-            if name in baseCatalog.keys():
+            if name in baseCatalog:
                 continue
             else:
                 raise ValueError("input base catalog does not have key %s"%(name))

--- a/examples/catalogsExamples.py
+++ b/examples/catalogsExamples.py
@@ -64,7 +64,7 @@ def examplePhoSimCatalogs():
                                'filetype':'phoSim_catalog_ZPOINT',
                                'obsMetadata':obs_metadata}
 
-    for objKey in objectDict.keys():
+    for objKey in objectDict:
         dbobj = objectDict[objKey]['dbobj']
         t = dbobj.getCatalog(objectDict[objKey]['filetype'],
                              obs_metadata=objectDict[objKey]['obsMetadata'],

--- a/python/lsst/sims/catUtils/supernovae/snObject.py
+++ b/python/lsst/sims/catUtils/supernovae/snObject.py
@@ -264,7 +264,7 @@ class SNObject(sncosmo.Model):
 
         """
         sncosmoParams = dict()
-        for param in SNstate.keys():
+        for param in SNstate:
             if param in SNCosmoModel.param_names:
                 sncosmoParams[param] = SNstate[param]
         sncosmoParams['mwebv'] = SNstate['MWE(B-V)']
@@ -289,7 +289,7 @@ class SNObject(sncosmo.Model):
 
         """
         sncosmoParams = dict()
-        for param in SNstate.keys():
+        for param in SNstate:
             if param in SNCosmoModel.param_names:
                 sncosmoParams[param] = SNstate[param]
         return sncosmoParams

--- a/tests/testArbitraryUncertaintyGetters.py
+++ b/tests/testArbitraryUncertaintyGetters.py
@@ -79,16 +79,11 @@ class CartoonUncertaintyTestCase(unittest.TestCase):
         inputDir = os.path.join(getPackageDir('sims_catUtils'), 'tests', 'testData')
         inputFile = os.path.join(inputDir, 'IndicesTestCatalogStars.txt')
         db = fileDBObject(inputFile, dtype=db_dtype, runtable='test', idColKey='id')
-        catName = os.path.join(getPackageDir('sims_catUtils'), 'tests', 'scratchSpace', 'cartoonStarCat.txt')
         cat = CartoonStars(db, obs_metadata=obs)
-        cat.write_catalog(catName)
-
-        dtype = np.dtype([(name, np.float) for name in cat.column_outputs])
-
-        controlData = np.genfromtxt(catName, dtype=dtype, delimiter=',')
-
-        if os.path.exists(catName):
-            os.unlink(catName)
+        with lsst.utils.tests.getTempFilePath('.txt') as catName:
+            cat.write_catalog(catName)
+            dtype = np.dtype([(name, np.float) for name in cat.column_outputs])
+            controlData = np.genfromtxt(catName, dtype=dtype, delimiter=',')
 
         db_columns = db.query_columns(['id', 'raJ2000', 'decJ2000', 'sedFilename', 'magNorm', 'galacticAv'])
 
@@ -137,17 +132,12 @@ class CartoonUncertaintyTestCase(unittest.TestCase):
         inputDir = os.path.join(getPackageDir('sims_catUtils'), 'tests', 'testData')
         inputFile = os.path.join(inputDir, 'IndicesTestCatalogStars.txt')
         db = fileDBObject(inputFile, dtype=db_dtype, runtable='test', idColKey='id')
-        catName = os.path.join(getPackageDir('sims_catUtils'), 'tests', 'scratchSpace', 'cartoonStarCat.txt')
         cat = CartoonStars(db, obs_metadata=obs, column_outputs=['lsst_u', 'lsst_g',
                                                                  'sigma_lsst_u', 'sigma_lsst_g'])
-        cat.write_catalog(catName)
-
-        dtype = np.dtype([(name, np.float) for name in cat._column_outputs])
-
-        controlData = np.genfromtxt(catName, dtype=dtype, delimiter=',')
-
-        if os.path.exists(catName):
-            os.unlink(catName)
+        with lsst.utils.tests.getTempFilePath('.txt') as catName:
+            cat.write_catalog(catName)
+            dtype = np.dtype([(name, np.float) for name in cat._column_outputs])
+            controlData = np.genfromtxt(catName, dtype=dtype, delimiter=',')
 
         db_columns = db.query_columns(['id', 'raJ2000', 'decJ2000', 'sedFilename', 'magNorm', 'galacticAv'])
 

--- a/tests/testCameraCoordsLSST.py
+++ b/tests/testCameraCoordsLSST.py
@@ -29,11 +29,6 @@ class CameraCoordLSST_testCase(unittest.TestCase):
     """
 
     def test_different_cameras(self):
-        scratch_dir = os.path.join(getPackageDir('sims_catUtils'),'tests',
-                                   'scratchSpace')
-
-        db_text_file = os.path.join(scratch_dir, 'cameraCoord_db_text.txt')
-
         rng = np.random.RandomState(6512)
 
         pointing_ra = 15.0
@@ -48,31 +43,28 @@ class CameraCoordLSST_testCase(unittest.TestCase):
         mudec_list = radiansFromArcsec(0.005)*rng.random_sample(n_obj)
         vrad_list = 100.0*rng.random_sample(n_obj)
 
-        with open(db_text_file, 'w') as out_file:
-            for ix, (rdeg, ddeg, rrad, drad, px, mura, mudec, vrad) in \
-            enumerate(zip(ra_list, dec_list,
-                          np.radians(ra_list), np.radians(dec_list),
-                          px_list, mura_list, mudec_list, vrad_list)):
+        with lsst.utils.tests.getTempFilePath('.txt') as db_text_file:
+            with open(db_text_file, 'w') as out_file:
+                for ix, (rdeg, ddeg, rrad, drad, px, mura, mudec, vrad) in \
+                    enumerate(zip(ra_list, dec_list,
+                              np.radians(ra_list), np.radians(dec_list),
+                              px_list, mura_list, mudec_list, vrad_list)):
 
-                out_file.write('%d %e %e %e %e %e %e %e %e\n' % (ix, rdeg, ddeg,
-                                                                 rrad, drad,
-                                                                 px,
-                                                                 mura, mudec,
-                                                                 vrad))
+                    out_file.write('%d %e %e %e %e %e %e %e %e\n' % (ix, rdeg, ddeg,
+                                                                     rrad, drad,
+                                                                     px,
+                                                                     mura, mudec,
+                                                                     vrad))
 
-        dtype = np.dtype([('id', int), ('raDeg', float), ('decDeg', float),
-                          ('raJ2000', float), ('decJ2000', float),
-                          ('parallax', float),
-                          ('properMotionRa', float), ('properMotionDec', float),
-                          ('radialVelocity', float)])
+            dtype = np.dtype([('id', int), ('raDeg', float), ('decDeg', float),
+                             ('raJ2000', float), ('decJ2000', float),
+                             ('parallax', float),
+                             ('properMotionRa', float), ('properMotionDec', float),
+                             ('radialVelocity', float)])
 
-
-        db = fileDBObject(db_text_file, dtype=dtype, idColKey='id')
-        db.raColName = 'raDeg'
-        db.decColName = 'decDeg'
-
-        if os.path.exists(db_text_file):
-            os.unlink(db_text_file)
+            db = fileDBObject(db_text_file, dtype=dtype, idColKey='id')
+            db.raColName = 'raDeg'
+            db.decColName = 'decDeg'
 
 
         class CameraCoordsCatalog(AstrometryStars, CameraCoords,

--- a/tests/testCompoundCatalogs.py
+++ b/tests/testCompoundCatalogs.py
@@ -1,5 +1,7 @@
 import unittest
 import os
+import shutil
+import tempfile
 import lsst.utils.tests
 from lsst.utils import getPackageDir
 
@@ -56,8 +58,11 @@ class StarCatalog(InstanceCatalog):
 class CompoundCatalogTest(unittest.TestCase):
 
     def setUp(self):
-        self.baseDir = os.path.join(getPackageDir('sims_catUtils'),
-                                    'tests', 'scratchSpace')
+        self.baseDir = tempfile.mkdtemp(dir=ROOT, prefix='compoundCatalogTest-')
+
+    def tearDown(self):
+        if os.path.exists(self.baseDir):
+            shutil.rmtree(self.baseDir)
 
     @unittest.skipIf(not _testCompoundCatalogs_is_connected,
                      "We are not connected to fatboy")
@@ -97,25 +102,18 @@ class CompoundCatalogTest(unittest.TestCase):
 
         totalCat.write_catalog(testFileName, write_header=False, chunk_size=10000)
 
-        controlFile = open(controlFileName, 'r')
-        control = controlFile.readlines()
+        with open(controlFileName, 'r') as controlFile:
+            control = controlFile.readlines()
         controlFile.close()
 
-        testFile = open(testFileName, 'r')
-        test = testFile.readlines()
-        testFile.close()
+        with open(testFileName, 'r') as testFile:
+            test = testFile.readlines()
 
         for line in control:
             self.assertIn(line, test)
 
         for line in test:
             self.assertIn(line, control)
-
-        if os.path.exists(controlFileName):
-            os.unlink(controlFileName)
-
-        if os.path.exists(testFileName):
-            os.unlink(testFileName)
 
     @unittest.skipIf(not _testCompoundCatalogs_is_connected,
                      "We are not connected to fatboy")
@@ -158,25 +156,17 @@ class CompoundCatalogTest(unittest.TestCase):
 
         totalCat.write_catalog(testFileName, write_header=False, chunk_size=10000)
 
-        controlFile = open(controlFileName, 'r')
-        control = controlFile.readlines()
-        controlFile.close()
+        with open(controlFileName, 'r') as controlFile:
+            control = controlFile.readlines()
 
-        testFile = open(testFileName, 'r')
-        test = testFile.readlines()
-        testFile.close()
+        with open(testFileName, 'r') as testFile:
+            test = testFile.readlines()
 
         for line in control:
             self.assertIn(line, test)
 
         for line in test:
             self.assertIn(line, control)
-
-        if os.path.exists(controlFileName):
-            os.unlink(controlFileName)
-
-        if os.path.exists(testFileName):
-            os.unlink(testFileName)
 
 
 class MemoryTestClass(lsst.utils.tests.MemoryTestCase):

--- a/tests/testCompoundCatalogs.py
+++ b/tests/testCompoundCatalogs.py
@@ -104,7 +104,6 @@ class CompoundCatalogTest(unittest.TestCase):
 
         with open(controlFileName, 'r') as controlFile:
             control = controlFile.readlines()
-        controlFile.close()
 
         with open(testFileName, 'r') as testFile:
             test = testFile.readlines()

--- a/tests/testCosmologyMixins.py
+++ b/tests/testCosmologyMixins.py
@@ -4,6 +4,7 @@ import os
 import unittest
 import lsst.utils.tests
 import numpy as np
+import tempfile
 
 from lsst.sims.utils.CodeUtilities import sims_clean_up
 from lsst.sims.utils import ObservationMetaData
@@ -14,6 +15,8 @@ from lsst.sims.catalogs.utils import myTestGals, makeGalTestDB
 
 from lsst.sims.catUtils.utils import testGalaxies
 from lsst.sims.catUtils.mixins import CosmologyMixin
+
+ROOT = os.path.abspath(os.path.dirname(__file__))
 
 
 def setup_module(module):
@@ -54,7 +57,7 @@ class CosmologyMixinUnitTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.dbName = 'cosmologyTestDB.db'
+        cls.dbName = tempfile.mktemp(prefix='cosmologyTestDB-', suffix=".db", dir=ROOT)
         cls.dbSize = 100
         if os.path.exists(cls.dbName):
             os.unlink(cls.dbName)
@@ -71,14 +74,6 @@ class CosmologyMixinUnitTest(unittest.TestCase):
 
     def setUp(self):
         self.obs = ObservationMetaData(mjd=59580.0)
-        self.catName = 'cosmologyCatalog.txt'
-        if os.path.exists(self.catName):
-            os.unlink(self.catName)
-
-    def tearDown(self):
-        if os.path.exists(self.catName):
-            os.unlink(self.catName)
-        del self.catName
 
     def testCosmologyCatalog(self):
         """
@@ -86,7 +81,8 @@ class CosmologyMixinUnitTest(unittest.TestCase):
         """
         dbObj = myTestGals(database=self.dbName)
         cat = cosmologicalGalaxyCatalog(dbObj, obs_metadata=self.obs)
-        cat.write_catalog(self.catName)
+        with lsst.utils.tests.getTempFilePath('.txt') as catName:
+            cat.write_catalog(catName)
 
     def testCatalogDistanceModulus(self):
         """

--- a/tests/testDitherColumnDetection.py
+++ b/tests/testDitherColumnDetection.py
@@ -4,10 +4,14 @@ import unittest
 import os
 import sqlite3
 import numpy as np
+import tempfile
+import shutil
 
 import lsst.utils.tests
 from lsst.utils import getPackageDir
 from lsst.sims.catUtils.utils import ObservationMetaDataGenerator
+
+ROOT = os.path.abspath(os.path.dirname(__file__))
 
 
 def setup_module(module):
@@ -25,17 +29,15 @@ class ObsMetaDataGenDitherTestClass(unittest.TestCase):
     def tearDownClass(cls):
         if os.path.exists(cls.fake_db_name):
             os.unlink(cls.fake_db_name)
+        if os.path.exists(cls.scratch_space):
+            shutil.rmtree(cls.scratch_space)
 
     @classmethod
     def setUpClass(cls):
-        cls.scratch_space = os.path.join(getPackageDir('sims_catUtils'),
-                                         'tests', 'scratchSpace')
+        cls.scratch_space = tempfile.mkdtemp(dir=ROOT, prefix='ObsMetaDataGenDitherTestClass-')
 
         cls.fake_db_name = os.path.join(cls.scratch_space,
                                         'dither_test_fake_opsim_sqlite.db')
-
-        if os.path.exists(cls.fake_db_name):
-            os.unlink(cls.fake_db_name)
 
         conn = sqlite3.connect(cls.fake_db_name)
         curs = conn.cursor()

--- a/tests/testFastLightCurveGenerator.py
+++ b/tests/testFastLightCurveGenerator.py
@@ -230,22 +230,22 @@ class Fast_agn_lc_gen_test_case(unittest.TestCase):
                                                        avBulge[ix], normBulge[ix])
                                       + "agn.spec;%s;%f\n" % (paramStr, normAgn[ix]))
 
-                dtype = np.dtype([
-                                 ('galid', np.int),
-                                 ('raDeg', np.float), ('decDeg', np.float),
-                                 ('raJ2000', np.float), ('decJ2000', np.float),
-                                 ('redshift', np.float),
-                                 ('sedFilenameDisk', str, 300), ('internalAvDisk', np.float),
-                                 ('magNormDisk', np.float),
-                                 ('sedFilenameBulge', str, 300), ('internalAvBulge', np.float),
-                                 ('magNormBulge', np.float),
-                                 ('sedFilenameAgn', str, 300), ('varParamStr', str, 600),
-                                 ('magNormAgn', np.float)
-                                 ])
+            dtype = np.dtype([
+                             ('galid', np.int),
+                             ('raDeg', np.float), ('decDeg', np.float),
+                             ('raJ2000', np.float), ('decJ2000', np.float),
+                             ('redshift', np.float),
+                             ('sedFilenameDisk', str, 300), ('internalAvDisk', np.float),
+                             ('magNormDisk', np.float),
+                             ('sedFilenameBulge', str, 300), ('internalAvBulge', np.float),
+                             ('magNormBulge', np.float),
+                             ('sedFilenameAgn', str, 300), ('varParamStr', str, 600),
+                             ('magNormAgn', np.float)
+                             ])
 
-                cls.agn_db = fileDBObject(txt_cat_name, delimiter=';',
-                                          runtable='test', dtype=dtype,
-                                          idColKey='galid')
+            cls.agn_db = fileDBObject(txt_cat_name, delimiter=';',
+                                      runtable='test', dtype=dtype,
+                                      idColKey='galid')
 
         cls.agn_db.raColName = 'raDeg'
         cls.agn_db.decColName = 'decDeg'

--- a/tests/testGetters.py
+++ b/tests/testGetters.py
@@ -2,6 +2,7 @@ from builtins import range
 import os
 import numpy as np
 import unittest
+import tempfile
 
 import lsst.utils.tests
 from lsst.utils import getPackageDir
@@ -15,6 +16,8 @@ from lsst.sims.photUtils import Sed, Bandpass, LSSTdefaults, calcMagError_sed
 from lsst.sims.photUtils import PhotometricParameters
 from lsst.sims.photUtils.utils import setM5
 from lsst.sims.catUtils.mixins import PhotometryStars, PhotometryGalaxies
+
+ROOT = os.path.abspath(os.path.dirname(__file__))
 
 
 def setup_module(module):
@@ -62,9 +65,7 @@ class testPhotometricUncertaintyGetters(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         lsstDefaults = LSSTdefaults()
-        cls.dbName = 'uncertaintyTestDB.db'
-        if os.path.exists(cls.dbName):
-            os.unlink(cls.dbName)
+        cls.dbName = tempfile.mktemp(prefix='uncertaintyTestDB-', suffix='.db', dir=ROOT)
 
         default_obs_metadata = makePhoSimTestDB(filename=cls.dbName, size=10, radius = 5.0)
         bandpass = ['u', 'g', 'r', 'i', 'z', 'y']

--- a/tests/testMLTflareModel.py
+++ b/tests/testMLTflareModel.py
@@ -4,6 +4,8 @@ import os
 import numpy as np
 import sqlite3
 import json
+import tempfile
+import shutil
 from astropy.analytic_functions import blackbody_lambda
 import lsst.utils.tests
 from lsst.utils import getPackageDir
@@ -17,6 +19,9 @@ from lsst.sims.photUtils import SedList, BandpassDict, Sed
 from lsst.sims.utils import radiansFromArcsec
 from lsst.sims.photUtils import PhotometricParameters
 from lsst.sims.utils.CodeUtilities import sims_clean_up
+
+ROOT = os.path.abspath(os.path.dirname(__file__))
+
 
 def setup_module(module):
     lsst.utils.tests.init()
@@ -53,8 +58,8 @@ class MLT_flare_test_case(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.scratch_dir = os.path.join(getPackageDir('sims_catUtils'),
-                                       'tests', 'scratchSpace')
+        cls.scratch_dir = tempfile.mkdtemp(dir=ROOT, prefix="MLT_flare_test_case-")
+
         # Create a dummy mlt light curve file
         cls.mlt_lc_name = os.path.join(cls.scratch_dir,
                                        'test_mlt_lc_file.npz')
@@ -119,6 +124,9 @@ class MLT_flare_test_case(unittest.TestCase):
 
         if os.path.exists(cls.db_name):
             os.unlink(cls.db_name)
+
+        if os.path.exists(cls.scratch_dir):
+            shutil.rmtree(cls.scratch_dir)
 
     def test_flare_lc_failure(self):
         """
@@ -497,14 +505,11 @@ class MLT_flare_mixed_with_none_model_test_case(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.scratch_dir = os.path.join(getPackageDir('sims_catUtils'),
-                                       'tests', 'scratchSpace')
+        cls.scratch_dir = tempfile.mkdtemp(dir=ROOT, prefix='MLT_flare_mixed_with_none_model_test_case-')
+
         # Create a dummy mlt light curve file
         cls.mlt_lc_name = os.path.join(cls.scratch_dir,
                                        'test_mlt_mixed_with_none_lc_file.npz')
-
-        if os.path.exists(cls.mlt_lc_name):
-            os.unlink(cls.mlt_lc_name)
 
         lc_files = {}
         amp = 1.0e32
@@ -522,9 +527,6 @@ class MLT_flare_mixed_with_none_model_test_case(unittest.TestCase):
 
         # Create a database of stars using these light curves
         cls.db_name = os.path.join(cls.scratch_dir, 'test_mlt_mixed_with_none_db.db')
-
-        if os.path.exists(cls.db_name):
-            os.unlink(cls.db_name)
 
         conn = sqlite3.connect(cls.db_name)
         cursor = conn.cursor()
@@ -567,6 +569,9 @@ class MLT_flare_mixed_with_none_model_test_case(unittest.TestCase):
 
         if os.path.exists(cls.db_name):
             os.unlink(cls.db_name)
+
+        if os.path.exists(cls.scratch_dir):
+            shutil.rmtree(cls.scratch_dir)
 
     def test_flare_magnitudes_mixed_with_none(self):
         """
@@ -741,8 +746,8 @@ class MLT_flare_mixed_with_dummy_model_test_case(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.scratch_dir = os.path.join(getPackageDir('sims_catUtils'),
-                                       'tests', 'scratchSpace')
+        cls.scratch_dir = tempfile.mkdtemp(dir=ROOT, prefix='MLT_flare_mixed_with_dummy_model_test_case-')
+
         # Create a dummy mlt light curve file
         cls.mlt_lc_name = os.path.join(cls.scratch_dir,
                                        'test_mlt_mixed_with_dummy_lc_file.npz')
@@ -823,6 +828,9 @@ class MLT_flare_mixed_with_dummy_model_test_case(unittest.TestCase):
 
         if os.path.exists(cls.dummy_lc_name):
             os.unlink(cls.dummy_lc_name)
+
+        if os.path.exists(cls.scratch_dir):
+            shutil.rmtree(cls.scratch_dir)
 
     def test_flare_magnitudes_mixed_with_dummy(self):
         """

--- a/tests/testPhoSimAstrometry.py
+++ b/tests/testPhoSimAstrometry.py
@@ -1,6 +1,7 @@
 import unittest
 import os
 import numpy as np
+import tempfile
 
 import lsst.utils.tests
 from lsst.utils import getPackageDir
@@ -15,6 +16,9 @@ from lsst.sims.catUtils.mixins import PhoSimAstrometryBase
 from lsst.sims.catUtils.mixins import PhoSimAstrometryStars
 from lsst.sims.catUtils.mixins import PhoSimAstrometryGalaxies
 from lsst.sims.utils.CodeUtilities import sims_clean_up
+
+ROOT = os.path.abspath(os.path.dirname(__file__))
+
 
 def setup_module(module):
     lsst.utils.tests.init()
@@ -48,9 +52,7 @@ class PhoSimAstrometryTestCase(unittest.TestCase):
     def setUpClass(cls):
         cls.scratch_dir = os.path.join(getPackageDir('sims_catUtils'),
                                        'tests', 'scratchSpace')
-        cls.db_name = os.path.join(cls.scratch_dir, 'PhoSimAstDB.db')
-        if os.path.exists(cls.db_name):
-            os.unlink(cls.db_name)
+        cls.db_name = tempfile.mktemp(dir=ROOT, prefix='PhoSimAstDB', suffix='.db')
         cls.obs = makePhoSimTestDB(filename=cls.db_name,
                                    size=1000)
 
@@ -65,16 +67,13 @@ class PhoSimAstrometryTestCase(unittest.TestCase):
         Test that we can go from raPhoSim, decPhoSim to ICRS coordinates
         in the case of stars (in radians)
         """
-        cat_name = os.path.join(self.scratch_dir, 'phosim_ast_star_cat_rad.txt')
-        if os.path.exists(cat_name):
-            os.unlink(cat_name)
-
         db = testStarsDBObj(driver='sqlite', database=self.db_name)
         cat = StarTestCatalog(db, obs_metadata=self.obs)
-        cat.write_catalog(cat_name)
-        dtype = np.dtype([('raICRS', float), ('decICRS', float),
-                          ('raPhoSim', float), ('decPhoSim', float)])
-        data = np.genfromtxt(cat_name, dtype=dtype)
+        with lsst.utils.tests.getTempFilePath('.txt') as cat_name:
+            cat.write_catalog(cat_name)
+            dtype = np.dtype([('raICRS', float), ('decICRS', float),
+                             ('raPhoSim', float), ('decPhoSim', float)])
+            data = np.genfromtxt(cat_name, dtype=dtype)
         self.assertGreater(len(data), 100)
         ra_pho_rad = np.radians(data['raPhoSim'])
         dec_pho_rad = np.radians(data['decPhoSim'])
@@ -102,8 +101,6 @@ class PhoSimAstrometryTestCase(unittest.TestCase):
         dist_bad = arcsecFromRadians(dist_bad)
         self.assertGreater(dist_bad.min(), dist.max())
 
-        if os.path.exists(cat_name):
-            os.unlink(cat_name)
         del db
 
     def test_stellar_astrometry_degrees(self):
@@ -111,16 +108,13 @@ class PhoSimAstrometryTestCase(unittest.TestCase):
         Test that we can go from raPhoSim, decPhoSim to ICRS coordinates
         in the case of stars (in degrees)
         """
-        cat_name = os.path.join(self.scratch_dir, 'phosim_ast_star_cat_deg.txt')
-        if os.path.exists(cat_name):
-            os.unlink(cat_name)
-
         db = testStarsDBObj(driver='sqlite', database=self.db_name)
         cat = StarTestCatalog(db, obs_metadata=self.obs)
-        cat.write_catalog(cat_name)
-        dtype = np.dtype([('raICRS', float), ('decICRS', float),
-                          ('raPhoSim', float), ('decPhoSim', float)])
-        data = np.genfromtxt(cat_name, dtype=dtype)
+        with lsst.utils.tests.getTempFilePath('.txt') as cat_name:
+            cat.write_catalog(cat_name)
+            dtype = np.dtype([('raICRS', float), ('decICRS', float),
+                             ('raPhoSim', float), ('decPhoSim', float)])
+            data = np.genfromtxt(cat_name, dtype=dtype)
         self.assertGreater(len(data), 100)
 
         # verify that, when transforming back to ICRS, we are within
@@ -144,8 +138,6 @@ class PhoSimAstrometryTestCase(unittest.TestCase):
         dist_bad = 3600.0*dist_bad
         self.assertGreater(dist_bad.min(), dist.max())
 
-        if os.path.exists(cat_name):
-            os.unlink(cat_name)
         del db
 
     def test_galaxy_astrometry_radians(self):
@@ -153,16 +145,13 @@ class PhoSimAstrometryTestCase(unittest.TestCase):
         Test that we can go from raPhoSim, decPhoSim to ICRS coordinates
         in the case of galaxies (in radians)
         """
-        cat_name = os.path.join(self.scratch_dir, 'phosim_ast_gal_cat_rad.txt')
-        if os.path.exists(cat_name):
-            os.unlink(cat_name)
-
         db = testGalaxyDiskDBObj(driver='sqlite', database=self.db_name)
         cat = GalaxyTestCatalog(db, obs_metadata=self.obs)
-        cat.write_catalog(cat_name)
-        dtype = np.dtype([('raICRS', float), ('decICRS', float),
-                          ('raPhoSim', float), ('decPhoSim', float)])
-        data = np.genfromtxt(cat_name, dtype=dtype)
+        with lsst.utils.tests.getTempFilePath('.txt') as cat_name:
+            cat.write_catalog(cat_name)
+            dtype = np.dtype([('raICRS', float), ('decICRS', float),
+                             ('raPhoSim', float), ('decPhoSim', float)])
+            data = np.genfromtxt(cat_name, dtype=dtype)
         self.assertGreater(len(data), 100)
         ra_pho_rad = np.radians(data['raPhoSim'])
         dec_pho_rad = np.radians(data['decPhoSim'])
@@ -190,8 +179,6 @@ class PhoSimAstrometryTestCase(unittest.TestCase):
         dist_bad = arcsecFromRadians(dist_bad)
         self.assertGreater(dist_bad.min(), dist.max())
 
-        if os.path.exists(cat_name):
-            os.unlink(cat_name)
         del db
 
     def test_galaxy_astrometry_degrees(self):
@@ -199,16 +186,13 @@ class PhoSimAstrometryTestCase(unittest.TestCase):
         Test that we can go from raPhoSim, decPhoSim to ICRS coordinates
         in the case of galaxies (in degrees)
         """
-        cat_name = os.path.join(self.scratch_dir, 'phosim_ast_gal_cat_deg.txt')
-        if os.path.exists(cat_name):
-            os.unlink(cat_name)
-
         db = testGalaxyDiskDBObj(driver='sqlite', database=self.db_name)
         cat = GalaxyTestCatalog(db, obs_metadata=self.obs)
-        cat.write_catalog(cat_name)
-        dtype = np.dtype([('raICRS', float), ('decICRS', float),
-                          ('raPhoSim', float), ('decPhoSim', float)])
-        data = np.genfromtxt(cat_name, dtype=dtype)
+        with lsst.utils.tests.getTempFilePath('.txt') as cat_name:
+            cat.write_catalog(cat_name)
+            dtype = np.dtype([('raICRS', float), ('decICRS', float),
+                             ('raPhoSim', float), ('decPhoSim', float)])
+            data = np.genfromtxt(cat_name, dtype=dtype)
         self.assertGreater(len(data), 100)
 
         # verify that, when transforming back to ICRS, we are within
@@ -232,8 +216,6 @@ class PhoSimAstrometryTestCase(unittest.TestCase):
         dist_bad = 3600.0*dist_bad
         self.assertGreater(dist_bad.min(), dist.max())
 
-        if os.path.exists(cat_name):
-            os.unlink(cat_name)
         del db
 
 

--- a/tests/testPhotometricIndices.py
+++ b/tests/testPhotometricIndices.py
@@ -1,6 +1,7 @@
 import os
 import numpy as np
 import unittest
+import tempfile
 import lsst.utils.tests
 
 from lsst.utils import getPackageDir
@@ -9,6 +10,8 @@ from lsst.sims.catalogs.db import fileDBObject
 from lsst.sims.catalogs.definitions import InstanceCatalog
 from lsst.sims.catUtils.mixins import (PhotometryStars, PhotometrySSM,
                                        PhotometryGalaxies)
+
+ROOT = os.path.abspath(os.path.dirname(__file__))
 
 
 def setup_module(module):
@@ -76,27 +79,21 @@ class IndexTestCaseStars(unittest.TestCase):
                               idColKey='id', dtype=dbdtype)
 
         cat = baselineStarCatalog(cls.db, obs_metadata=cls.obs)
-        cls.catName = os.path.join(getPackageDir('sims_catUtils'), 'tests',
-                                   'scratchSpace', 'indicesStarsControlCat.txt')
-
+        cls.catName = tempfile.mktemp(dir=ROOT, prefix='indicesStarControlCat-', suffix='.txt')
         cat.write_catalog(cls.catName)
         cls.controlData = np.genfromtxt(cls.catName, dtype=baselineDtype, delimiter=',')
-
-    @classmethod
-    def tearDownClass(cls):
-        if os.path.exists(cls.catName):
-            os.unlink(cls.catName)
+        os.unlink(cls.catName)
 
     def test_u_star_catalog(self):
         """
         Test that a catalog which only cares about u does not calculate any other magnitudes.
         """
-        catName = os.path.join(getPackageDir('sims_catUtils'), 'tests', 'scratchSpace', 'indicesUCat.txt')
         dtype = np.dtype([(name, np.float) for name in uStarCatalog.column_outputs])
 
         cat = uStarCatalog(self.db, obs_metadata=self.obs)
-        cat.write_catalog(catName)
-        testData = np.genfromtxt(catName, dtype=dtype, delimiter=',')
+        with lsst.utils.tests.getTempFilePath('.txt') as catName:
+            cat.write_catalog(catName)
+            testData = np.genfromtxt(catName, dtype=dtype, delimiter=',')
         np.testing.assert_array_almost_equal(self.controlData['raJ2000'], testData['raJ2000'], 10)
         np.testing.assert_array_almost_equal(self.controlData['decJ2000'], testData['decJ2000'], 10)
         np.testing.assert_array_almost_equal(self.controlData['lsst_u'], testData['lsst_u'], 10)
@@ -113,19 +110,16 @@ class IndexTestCaseStars(unittest.TestCase):
         self.assertNotIn('lsst_y', cat._actually_calculated_columns)
         self.assertNotIn('sigma_lsst_y', cat._actually_calculated_columns)
 
-        if os.path.exists(catName):
-            os.unlink(catName)
-
     def test_gz_star_catalog(self):
         """
         Test that a catalog which only cares about g and z does not calculate any other magnitudes
         """
-        catName = os.path.join(getPackageDir('sims_catUtils'), 'tests', 'scratchSpace', 'indicesGZCat.txt')
         dtype = np.dtype([(name, np.float) for name in gzStarCatalog.column_outputs])
 
         cat = gzStarCatalog(self.db, obs_metadata=self.obs)
-        cat.write_catalog(catName)
-        testData = np.genfromtxt(catName, dtype=dtype, delimiter=',')
+        with lsst.utils.tests.getTempFilePath('.txt') as catName:
+            cat.write_catalog(catName)
+            testData = np.genfromtxt(catName, dtype=dtype, delimiter=',')
         np.testing.assert_array_almost_equal(self.controlData['raJ2000'], testData['raJ2000'], 10)
         np.testing.assert_array_almost_equal(self.controlData['decJ2000'], testData['decJ2000'], 10)
         np.testing.assert_array_almost_equal(self.controlData['lsst_g'], testData['lsst_g'], 10)
@@ -142,21 +136,17 @@ class IndexTestCaseStars(unittest.TestCase):
         self.assertNotIn('lsst_y', cat._actually_calculated_columns)
         self.assertNotIn('sigma_lsst_y', cat._actually_calculated_columns)
 
-        if os.path.exists(catName):
-            os.unlink(catName)
-
     def test_gz_uncertainty_star_catalog(self):
         """
         Test that a catalog which only cares about g and z uncertainties
         does not calculate any other magnitudes
         """
-        catName = os.path.join(getPackageDir('sims_catUtils'),
-                               'tests', 'scratchSpace', 'indicesGZUncertaintyCat.txt')
         dtype = np.dtype([(name, np.float) for name in gzUncertaintyStarCatalog.column_outputs])
 
         cat = gzUncertaintyStarCatalog(self.db, obs_metadata=self.obs)
-        cat.write_catalog(catName)
-        testData = np.genfromtxt(catName, dtype=dtype, delimiter=',')
+        with lsst.utils.tests.getTempFilePath('.txt') as catName:
+            cat.write_catalog(catName)
+            testData = np.genfromtxt(catName, dtype=dtype, delimiter=',')
         np.testing.assert_array_almost_equal(self.controlData['raJ2000'], testData['raJ2000'], 10)
         np.testing.assert_array_almost_equal(self.controlData['decJ2000'], testData['decJ2000'], 10)
         np.testing.assert_array_almost_equal(self.controlData['sigma_lsst_g'], testData['sigma_lsst_g'], 10)
@@ -172,9 +162,6 @@ class IndexTestCaseStars(unittest.TestCase):
         self.assertNotIn('sigma_lsst_y', cat._actually_calculated_columns)
         self.assertIn('lsst_g', cat._actually_calculated_columns)
         self.assertIn('lsst_z', cat._actually_calculated_columns)
-
-        if os.path.exists(catName):
-            os.unlink(catName)
 
 
 class baselineSSMCatalog(InstanceCatalog, PhotometrySSM):
@@ -234,27 +221,20 @@ class IndexTestCaseSSM(unittest.TestCase):
                               idColKey='id', dtype=dbdtype)
 
         cat = baselineSSMCatalog(cls.db, obs_metadata=cls.obs)
-        cls.catName = os.path.join(getPackageDir('sims_catUtils'), 'tests',
-                                   'scratchSpace', 'indicesSSMControlCat.txt')
-
-        cat.write_catalog(cls.catName)
-        cls.controlData = np.genfromtxt(cls.catName, dtype=baselineDtype, delimiter=',')
-
-    @classmethod
-    def tearDownClass(cls):
-        if os.path.exists(cls.catName):
-            os.unlink(cls.catName)
+        with lsst.utils.tests.getTempFilePath('.txt') as catName:
+            cat.write_catalog(catName)
+            cls.controlData = np.genfromtxt(catName, dtype=baselineDtype, delimiter=',')
 
     def test_u_ssm_catalog(self):
         """
         Test that a catalog which only cares about u does not calculate any other magnitudes.
         """
-        catName = os.path.join(getPackageDir('sims_catUtils'), 'tests', 'scratchSpace', 'indicesUssmCat.txt')
         dtype = np.dtype([(name, np.float) for name in uSSMCatalog.column_outputs])
 
         cat = uSSMCatalog(self.db, obs_metadata=self.obs)
-        cat.write_catalog(catName)
-        testData = np.genfromtxt(catName, dtype=dtype, delimiter=',')
+        with lsst.utils.tests.getTempFilePath('.txt') as catName:
+            cat.write_catalog(catName)
+            testData = np.genfromtxt(catName, dtype=dtype, delimiter=',')
         np.testing.assert_array_almost_equal(self.controlData['lsst_u'], testData['lsst_u'], 10)
         np.testing.assert_array_almost_equal(self.controlData['sigma_lsst_u'], testData['sigma_lsst_u'], 10)
 
@@ -269,19 +249,16 @@ class IndexTestCaseSSM(unittest.TestCase):
         self.assertNotIn('lsst_y', cat._actually_calculated_columns)
         self.assertNotIn('sigma_lsst_y', cat._actually_calculated_columns)
 
-        if os.path.exists(catName):
-            os.unlink(catName)
-
     def test_gz_ssm_catalog(self):
         """
         Test that a catalog which only cares about g and z does not calculate any other magnitudes
         """
-        catName = os.path.join(getPackageDir('sims_catUtils'), 'tests', 'scratchSpace', 'indicesGZssmCat.txt')
         dtype = np.dtype([(name, np.float) for name in gzSSMCatalog.column_outputs])
 
         cat = gzSSMCatalog(self.db, obs_metadata=self.obs)
-        cat.write_catalog(catName)
-        testData = np.genfromtxt(catName, dtype=dtype, delimiter=',')
+        with lsst.utils.tests.getTempFilePath('.txt') as catName:
+            cat.write_catalog(catName)
+            testData = np.genfromtxt(catName, dtype=dtype, delimiter=',')
         np.testing.assert_array_almost_equal(self.controlData['lsst_g'], testData['lsst_g'], 10)
         np.testing.assert_array_almost_equal(self.controlData['sigma_lsst_g'], testData['sigma_lsst_g'], 10)
         np.testing.assert_array_almost_equal(self.controlData['lsst_z'], testData['lsst_z'], 10)
@@ -296,21 +273,17 @@ class IndexTestCaseSSM(unittest.TestCase):
         self.assertNotIn('lsst_y', cat._actually_calculated_columns)
         self.assertNotIn('sigma_lsst_y', cat._actually_calculated_columns)
 
-        if os.path.exists(catName):
-            os.unlink(catName)
-
     def test_gz_uncertainty_ssm_catalog(self):
         """
         Test that a catalog which only cares about g and z uncertainties
         does not calculate any other magnitudes
         """
-        catName = os.path.join(getPackageDir('sims_catUtils'),
-                               'tests', 'scratchSpace', 'indicesGZssmUncertaintyCat.txt')
         dtype = np.dtype([(name, np.float) for name in gzUncertaintySSMCatalog.column_outputs])
 
         cat = gzUncertaintySSMCatalog(self.db, obs_metadata=self.obs)
-        cat.write_catalog(catName)
-        testData = np.genfromtxt(catName, dtype=dtype, delimiter=',')
+        with lsst.utils.tests.getTempFilePath('.txt') as catName:
+            cat.write_catalog(catName)
+            testData = np.genfromtxt(catName, dtype=dtype, delimiter=',')
         np.testing.assert_array_almost_equal(self.controlData['sigma_lsst_g'], testData['sigma_lsst_g'], 10)
         np.testing.assert_array_almost_equal(self.controlData['sigma_lsst_z'], testData['sigma_lsst_z'], 10)
 
@@ -324,10 +297,6 @@ class IndexTestCaseSSM(unittest.TestCase):
         self.assertNotIn('sigma_lsst_y', cat._actually_calculated_columns)
         self.assertIn('lsst_g', cat._actually_calculated_columns)
         self.assertIn('lsst_z', cat._actually_calculated_columns)
-
-        if os.path.exists(catName):
-            os.unlink(catName)
-
 
 class baselineGalaxyCatalog(InstanceCatalog, PhotometryGalaxies):
     column_outputs = ['uBulge', 'gBulge', 'rBulge', 'iBulge', 'zBulge', 'yBulge',
@@ -399,31 +368,24 @@ class IndexTestCaseGalaxies(unittest.TestCase):
 
         cls.db.objectTypeId = 44
 
-        catName = os.path.join(getPackageDir('sims_catUtils'), 'tests',
-                               'scratchSpace', 'galaxyPhotIndicesBaseline.txt')
-
         cat = baselineGalaxyCatalog(cls.db, obs_metadata=cls.obs)
-        cat.write_catalog(catName)
-
         dtype = np.dtype([(name, np.float) for name in cat.column_outputs])
-
+        catName = tempfile.mktemp(dir=ROOT, prefix='', suffix='.txt')
+        cat.write_catalog(catName)
         cls.controlData = np.genfromtxt(catName, dtype=dtype, delimiter=',')
-
-        if os.path.exists(catName):
-            os.unlink(catName)
+        os.remove(catName)
 
     def test_u_catalog(self):
         """
         Test that a catalog which only requests u band magnitudes does not
         calculate anything it shouldn't
         """
-        catName = os.path.join(getPackageDir('sims_catUtils'), 'tests',
-                               'scratchSpace', 'galPhotIndicesUTestCat.txt')
         cat = uGalaxyCatalog(self.db, obs_metadata=self.obs)
         dtype = np.dtype([(name, np.float) for name in cat.column_outputs])
-        cat.write_catalog(catName)
+        with lsst.utils.tests.getTempFilePath('.txt') as catName:
+            cat.write_catalog(catName)
 
-        testData = np.genfromtxt(catName, dtype=dtype, delimiter=',')
+            testData = np.genfromtxt(catName, dtype=dtype, delimiter=',')
 
         for name in ('uBulge', 'uDisk', 'uAgn', 'lsst_u',
                      'sigma_uBulge', 'sigma_uDisk', 'sigma_uAgn', 'sigma_lsst_u'):
@@ -472,21 +434,17 @@ class IndexTestCaseGalaxies(unittest.TestCase):
         self.assertNotIn('sigma_lsst_z', cat._actually_calculated_columns)
         self.assertNotIn('sigma_lsst_y', cat._actually_calculated_columns)
 
-        if os.path.exists(catName):
-            os.unlink(catName)
-
     def test_gz_catalog(self):
         """
         Test that a catalog which only requests g and z band magnitudes does not
         calculate anything it shouldn't
         """
-        catName = os.path.join(getPackageDir('sims_catUtils'), 'tests',
-                               'scratchSpace', 'galPhotIndicesGZTestCat.txt')
         cat = gzGalaxyCatalog(self.db, obs_metadata=self.obs)
         dtype = np.dtype([(name, np.float) for name in cat.column_outputs])
-        cat.write_catalog(catName)
+        with lsst.utils.tests.getTempFilePath('.txt') as catName:
+            cat.write_catalog(catName)
 
-        testData = np.genfromtxt(catName, dtype=dtype, delimiter=',')
+            testData = np.genfromtxt(catName, dtype=dtype, delimiter=',')
 
         for name in ('gBulge', 'gDisk', 'gAgn', 'lsst_g',
                      'zBulge', 'zDisk', 'zAgn', 'lsst_z',
@@ -530,10 +488,6 @@ class IndexTestCaseGalaxies(unittest.TestCase):
         self.assertNotIn('sigma_lsst_r', cat._actually_calculated_columns)
         self.assertNotIn('sigma_lsst_i', cat._actually_calculated_columns)
         self.assertNotIn('sigma_lsst_y', cat._actually_calculated_columns)
-
-        if os.path.exists(catName):
-            os.unlink(catName)
-
 
 class MemoryTestClass(lsst.utils.tests.MemoryTestCase):
     pass

--- a/tests/testSN.py
+++ b/tests/testSN.py
@@ -120,7 +120,7 @@ class SNObject_tests(unittest.TestCase):
         entries for all keys and does not contain keys with None type Values.
         """
         myDict = self.SN_extincted.SNstate
-        for key in myDict.keys():
+        for key in myDict:
             assert myDict[key] is not None
 
     def test_attributeDefaults(self):
@@ -461,7 +461,7 @@ class SNIaCatalog_tests(unittest.TestCase):
                  'cosmologicalDistanceModulus', 'mwebv']
         s = "Testing Equality across {0:2d} pointings for reported properties"
         s += " of SN {1:8d} of the property "
-        for key in lcs.groups.keys():
+        for key in lcs.groups:
             df = lcs.get_group(key)
             for prop in props:
                 print(s.format(len(df), df.snid.iloc[0]) + prop)
@@ -482,7 +482,7 @@ class SNIaCatalog_tests(unittest.TestCase):
         newlcs = self.buildLCfromInstanceCatFilenames(fnameList)
         oldlcs = self.buildLCfromInstanceCatFilenames(self.fnameList)
 
-        for key in oldlcs.groups.keys():
+        for key in oldlcs.groups:
             df_old = oldlcs.get_group(key)
             df_old.sort_values(['time', 'band'], inplace=True)
             df_new = newlcs.get_group(key)

--- a/tests/testSN.py
+++ b/tests/testSN.py
@@ -283,7 +283,7 @@ class SNObject_tests(unittest.TestCase):
         # Test 1.
         self.assertGreater(low_x0, orig_x0)
         # Test 2.
-        self.assertEqual(peakabsMag, lowPeakAbsMag)
+        self.assertAlmostEqual(peakabsMag, lowPeakAbsMag, places=14)
 
         # Test Case for higher redshift
         self.SN_extincted.redshift(z=highz, cosmo=cosmo)
@@ -293,7 +293,7 @@ class SNObject_tests(unittest.TestCase):
         # Test 1.
         self.assertLess(high_x0, orig_x0)
         # Test 2.
-        self.assertEqual(peakabsMag, HiPeakAbsMag)
+        self.assertAlmostEqual(peakabsMag, HiPeakAbsMag, places=14)
 
     def test_bandFluxErrorWorks(self):
         """

--- a/tests/testSN.py
+++ b/tests/testSN.py
@@ -21,6 +21,8 @@ import os
 import sqlite3
 import numpy as np
 import unittest
+import tempfile
+import shutil
 
 # External packages used
 # import pandas as pd
@@ -58,6 +60,8 @@ try:
     get_config_dir()
 except:
     _skip_sn_tests = True
+
+ROOT = os.path.abspath(os.path.dirname(__file__))
 
 
 def setup_module(module):
@@ -308,7 +312,7 @@ class SNObject_tests(unittest.TestCase):
         print(e)
         assert not(np.isinf(e) or np.isnan(e))
 
-    
+
 
 
 
@@ -320,8 +324,7 @@ class SNIaCatalog_tests(unittest.TestCase):
     def setUpClass(cls):
 
         # Set directory where scratch work will be done
-        cls.scratchDir = os.path.join(getPackageDir('sims_catUtils'), 'tests',
-                                      'scratchSpace')
+        cls.scratchDir = tempfile.mkdtemp(dir=ROOT, prefix='scratchSpace-')
 
         # ObsMetaData instance with spatial window within which we will
         # put galaxies in a fake galaxy catalog
@@ -403,7 +406,7 @@ class SNIaCatalog_tests(unittest.TestCase):
         sncatalog.suppressDimSN = True
         sncatalog.midSurveyTime = sncatalog.mjdobs - 20.
         sncatalog.snFrequency = 1.0
-        cls.fullCatalog = cls.scratchDir + '/testSNCatalogTest.dat'
+        cls.fullCatalog = os.path.join(cls.scratchDir, 'testSNCatalogTest.dat')
         sncatalog.write_catalog(cls.fullCatalog)
 
         # Create a SNCatalog based on GalDB, and having times of explosions
@@ -424,6 +427,8 @@ class SNIaCatalog_tests(unittest.TestCase):
 
         if os.path.exists(cls.fullCatalog):
             os.unlink(cls.fullCatalog)
+        if os.path.exists(cls.scratchDir):
+            shutil.rmtree(cls.scratchDir)
 
     def test_writingfullCatalog(self):
         """
@@ -622,8 +627,8 @@ class SNIaLightCurveTest(unittest.TestCase):
         dec_list = rng.random_sample(n_sne) * 4.0 - 69.0
         zz_list = rng.random_sample(n_sne) * 1.0 + 0.05
 
-        cls.input_cat_name = os.path.join(getPackageDir("sims_catUtils"), "tests")
-        cls.input_cat_name = os.path.join(cls.input_cat_name, "scratchSpace", "sne_input_cat.txt")
+        cls.scratchDir = tempfile.mkdtemp(dir=ROOT, prefix='scratchSpace-')
+        cls.input_cat_name = os.path.join(cls.scratchDir, "sne_input_cat.txt")
 
         with open(cls.input_cat_name, "w") as output_file:
             for ix in range(n_sne):
@@ -653,6 +658,8 @@ class SNIaLightCurveTest(unittest.TestCase):
         sims_clean_up()
         if os.path.exists(cls.input_cat_name):
             os.unlink(cls.input_cat_name)
+        if os.path.exists(cls.scratchDir):
+            shutil.rmtree(cls.scratchDir)
 
     def test_sne_light_curves(self):
         """

--- a/tests/testSSM_Diasources.py
+++ b/tests/testSSM_Diasources.py
@@ -77,8 +77,6 @@ class createSSMSourceCatalogsTest(unittest.TestCase):
 
     def test_ssm_catalog_creation(self):
 
-        output_cat = os.path.join(getPackageDir('sims_catUtils'), 'tests', 'scratchSpace', 'catsim_ssm_test')
-
         t = time.time()
         # Fake opsim data.
         database = os.path.join(getPackageDir('SIMS_DATA'), 'OpSimData/opsimblitz1_1133_sqlite.db')
@@ -101,9 +99,6 @@ class createSSMSourceCatalogsTest(unittest.TestCase):
 
         try:
             ssmObj = SolarSystemObj()
-
-            if os.path.exists(output_cat):
-                os.unlink(output_cat)
 
             for obsMeta in obsMetaDataResults:
                 # But moving objects databases are not currently complete for all years.
@@ -129,11 +124,12 @@ class createSSMSourceCatalogsTest(unittest.TestCase):
                 mySsmDb.photParams = photParams
 
                 try:
-                    mySsmDb.write_catalog(output_cat, write_header=write_header, write_mode=write_mode)
+                    with lsst.utils.tests.getTempFilePath('.txt') as output_cat:
+                        mySsmDb.write_catalog(output_cat, write_header=write_header, write_mode=write_mode)
 
-                    # verify that we did not write an empty catalog
-                    with open(output_cat, 'r') as input_file:
-                        lines = input_file.readlines()
+                        # verify that we did not write an empty catalog
+                        with open(output_cat, 'r') as input_file:
+                            lines = input_file.readlines()
                         self.assertGreater(len(lines), 1)
                 except:
                     # This is because the solar system object 'tables'
@@ -153,9 +149,6 @@ class createSSMSourceCatalogsTest(unittest.TestCase):
                 dt, t = dtime(t)
                 print('To query solar system objects: %f seconds (obs MJD time %f)' % (dt, obs.mjd.TAI))
 
-                if os.path.exists(output_cat):
-                    os.unlink(output_cat)
-
         except:
             trace = traceback.extract_tb(sys.exc_info()[2], limit=20)
             msg = sys.exc_info()[1].args[0]
@@ -167,9 +160,6 @@ class createSSMSourceCatalogsTest(unittest.TestCase):
                 pass
             else:
                 raise
-
-        if os.path.exists(output_cat):
-            os.unlink(output_cat)
 
 
 class MemoryTestClass(lsst.utils.tests.MemoryTestCase):

--- a/tests/testSSMmixins.py
+++ b/tests/testSSMmixins.py
@@ -76,16 +76,15 @@ class SSMphotometryTest(unittest.TestCase):
         """
         Test that PhotometrySSM properly calculates LSST magnitudes
         """
-        catName = os.path.join(getPackageDir('sims_catUtils'), 'tests', 'scratchSpace', 'lsstSsmPhotCat.txt')
-
         cat = LSST_SSM_photCat(self.photDB)
-        cat.write_catalog(catName)
 
         dtype = np.dtype([('id', np.int), ('u', np.float), ('g', np.float),
                           ('r', np.float), ('i', np.float), ('z', np.float),
                           ('y', np.float)])
 
-        testData = np.genfromtxt(catName, dtype=dtype, delimiter=',')
+        with lsst.utils.tests.getTempFilePath('.txt') as catName:
+            cat.write_catalog(catName)
+            testData = np.genfromtxt(catName, dtype=dtype, delimiter=',')
         self.assertGreater(len(testData), 0)
 
         controlData = np.genfromtxt(self.dbFile, dtype=self.dtype)
@@ -101,19 +100,12 @@ class SSMphotometryTest(unittest.TestCase):
             for jj, bpName in enumerate(['u', 'g', 'r', 'i', 'z', 'y']):
                 self.assertAlmostEqual(controlMags[ii][jj], testData[bpName][ii], 10)
 
-        if os.path.exists(catName):
-            os.unlink(catName)
-
     def testManyMagSystems(self):
         """
         Test that the SSM photometry mixin can simultaneously calculate magnitudes
         in multiple bandpass systems
         """
-        catName = os.path.join(getPackageDir('sims_catUtils'),
-                               'tests', 'scratchSpace', 'compoundSsmPhotCat.txt')
-
         cat = Compound_SSM_photCat(self.photDB)
-        cat.write_catalog(catName)
 
         dtype = np.dtype([('id', np.int), ('lsst_u', np.float), ('lsst_g', np.float),
                           ('lsst_r', np.float), ('lsst_i', np.float), ('lsst_z', np.float),
@@ -122,7 +114,9 @@ class SSMphotometryTest(unittest.TestCase):
                           ('cartoon_r', np.float), ('cartoon_i', np.float),
                           ('cartoon_z', np.float)])
 
-        testData = np.genfromtxt(catName, dtype=dtype, delimiter=',')
+        with lsst.utils.tests.getTempFilePath('.txt') as catName:
+            cat.write_catalog(catName)
+            testData = np.genfromtxt(catName, dtype=dtype, delimiter=',')
         self.assertGreater(len(testData), 0)
 
         controlData = np.genfromtxt(self.dbFile, dtype=self.dtype)
@@ -146,17 +140,11 @@ class SSMphotometryTest(unittest.TestCase):
             for jj, bpName in enumerate(['cartoon_u', 'cartoon_g', 'cartoon_r', 'cartoon_i', 'cartoon_z']):
                 self.assertAlmostEqual(controlCartoonMags[ii][jj], testData[bpName][ii], 10)
 
-        if os.path.exists(catName):
-            os.unlink(catName)
-
     def testDmagExceptions(self):
         """
         Test that the dmagTrailing and dmagDetection getters raise expected
         exceptions
         """
-        catName = os.path.join(getPackageDir('sims_catUtils'),
-                               'tests', 'scratchSpace', 'ssmDmagCatExceptions.txt')
-
         obs = ObservationMetaData()
         with self.assertRaises(RuntimeError) as context:
             cat = SSM_dmagCat(self.photDB, obs_metadata=obs)
@@ -172,12 +160,10 @@ class SSMphotometryTest(unittest.TestCase):
         with self.assertRaises(RuntimeError) as context:
             cat = SSM_dmagCat(self.photDB, obs_metadata=obs)
             cat.photParams = None
-            cat.write_catalog(catName)
+            with lsst.utils.tests.getTempFilePath('.txt') as catName:
+                cat.write_catalog(catName)
         self.assertIn("does not have an associated PhotometricParameters",
                       context.exception.args[0])
-
-        if os.path.exists(catName):
-            os.unlink(catName)
 
     def testDmag(self):
         """
@@ -186,15 +172,15 @@ class SSMphotometryTest(unittest.TestCase):
 
         obs = ObservationMetaData(bandpassName = 'u', seeing=1.48)
         photParams = PhotometricParameters()
-        catName = os.path.join(getPackageDir('sims_catUtils'), 'tests', 'scratchSpace', 'ssmDmagCat.txt')
 
         controlData = np.genfromtxt(self.dbFile, dtype=self.dtype)
 
         cat = SSM_dmagCat(self.photDB, obs_metadata=obs)
-        cat.write_catalog(catName)
 
         dtype = np.dtype([('id', np.int), ('dmagTrail', np.float), ('dmagDetect', np.float)])
-        testData = np.genfromtxt(catName, dtype=dtype, delimiter=',')
+        with lsst.utils.tests.getTempFilePath('.txt') as catName:
+            cat.write_catalog(catName)
+            testData = np.genfromtxt(catName, dtype=dtype, delimiter=',')
         self.assertGreater(len(testData), 0)
 
         a_trail = 0.76
@@ -216,9 +202,6 @@ class SSMphotometryTest(unittest.TestCase):
 
         np.testing.assert_array_almost_equal(dmagTrailControl, testData['dmagTrail'], 10)
         np.testing.assert_array_almost_equal(dmagDetectControl, testData['dmagDetect'], 10)
-
-        if os.path.exists(catName):
-            os.unlink(catName)
 
 
 class SSM_astrometryCat(InstanceCatalog, AstrometrySSM):
@@ -251,9 +234,6 @@ class SSMastrometryTest(unittest.TestCase):
         into observed RA, Dec
         """
 
-        catName = os.path.join(getPackageDir('sims_catUtils'), 'tests',
-                               'scratchSpace', 'ssmAstrometryCat.txt')
-
         dtype = np.dtype([('id', np.int),
                           ('raObserved', np.float), ('decObserved', np.float)])
 
@@ -268,9 +248,10 @@ class SSMastrometryTest(unittest.TestCase):
             obs = ObservationMetaData(pointingRA=raPointing, pointingDec=decPointing, mjd=mjd)
 
             cat = SSM_astrometryCat(self.astDB, obs_metadata=obs)
-            cat.write_catalog(catName)
+            with lsst.utils.tests.getTempFilePath('.txt') as catName:
+                cat.write_catalog(catName)
 
-            testData = np.genfromtxt(catName, dtype=dtype, delimiter=',')
+                testData = np.genfromtxt(catName, dtype=dtype, delimiter=',')
             self.assertGreater(len(testData), 0)
 
             raObservedControl, decObservedControl = _observedFromICRS(controlData['raJ2000'],
@@ -281,28 +262,21 @@ class SSMastrometryTest(unittest.TestCase):
             np.testing.assert_array_almost_equal(raObservedControl, testData['raObserved'], 10)
             np.testing.assert_array_almost_equal(decObservedControl, testData['decObserved'], 10)
 
-            if os.path.exists(catName):
-                os.unlink(catName)
-
     def testSkyVelocity(self):
         """
         Test that getter for sky velocity correctly calculates its output
         """
-        catName = os.path.join(getPackageDir('sims_catUtils'), 'tests', 'scratchSpace', 'ssmVelocityCat.txt')
-
         controlData = np.genfromtxt(self.dbFile, dtype=self.dtype)
         controlVel = np.sqrt(np.power(controlData['velRa'], 2) + np.power(controlData['velDec'], 2))
 
         cat = SSM_velocityCat(self.astDB)
-        cat.write_catalog(catName)
         dtype = np.dtype([('id', np.int), ('vel', np.float)])
-        testData = np.genfromtxt(catName, dtype=dtype)
+        with lsst.utils.tests.getTempFilePath('.txt') as catName:
+            cat.write_catalog(catName)
+            testData = np.genfromtxt(catName, dtype=dtype)
         self.assertGreater(len(testData), 0)
 
         np.testing.assert_array_almost_equal(testData['vel'], controlVel, 10)
-
-        if os.path.exists(catName):
-            os.unlink(catName)
 
 
 class MemoryTestClass(lsst.utils.tests.MemoryTestCase):

--- a/tests/testVariabilityInfrastructure.py
+++ b/tests/testVariabilityInfrastructure.py
@@ -5,6 +5,8 @@ from builtins import object
 import os
 import numpy as np
 import unittest
+import shutil
+import tempfile
 import lsst.utils.tests
 from lsst.sims.utils.CodeUtilities import sims_clean_up
 from lsst.sims.catalogs.utils import makeStarTestDB, myTestStars
@@ -13,6 +15,8 @@ from lsst.sims.catalogs.definitions import InstanceCatalog
 from lsst.sims.catalogs.decorators import compound
 from lsst.sims.catUtils.mixins import PhotometryStars, PhotometryGalaxies
 from lsst.sims.photUtils import BandpassDict
+
+ROOT = os.path.abspath(os.path.dirname(__file__))
 
 
 def setup_module(module):
@@ -175,26 +179,19 @@ class VariabilityDesignTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.starDbName = 'VariabilityInfrastructureTestStarDB.db'
-        if os.path.exists(cls.starDbName):
-            os.unlink(cls.starDbName)
+        cls.scratch_dir = tempfile.mkdtemp(dir=ROOT, prefix='VariabilityDesignTest-')
 
+        cls.starDbName = os.path.join(cls.scratch_dir, 'VariabilityInfrastructureTestStarDB.db')
         makeStarTestDB(filename=cls.starDbName)
 
-        cls.galaxyDbName = 'VariabilityInfrastructureTestGalaxyDB.db'
-        if os.path.exists(cls.galaxyDbName):
-            os.unlink(cls.galaxyDbname)
-
+        cls.galaxyDbName = os.path.join(cls.scratch_dir, 'VariabilityInfrastructureTestGalaxyDB.db')
         makeGalTestDB(filename=cls.galaxyDbName)
 
     @classmethod
     def tearDownClass(cls):
         sims_clean_up()
-        if os.path.exists(cls.starDbName):
-            os.unlink(cls.starDbName)
-
-        if os.path.exists(cls.galaxyDbName):
-            os.unlink(cls.galaxyDbName)
+        if os.path.exists(cls.scratch_dir):
+            shutil.rmtree(cls.scratch_dir)
 
     def setUp(self):
         self.starDB = myTestStars(database=self.starDbName)

--- a/tests/testVariabilityMixins.py
+++ b/tests/testVariabilityMixins.py
@@ -5,6 +5,8 @@ import unittest
 import numpy as np
 import sqlite3
 import json
+import tempfile
+import shutil
 import lsst.utils.tests
 from lsst.utils import getPackageDir
 from lsst.sims.utils.CodeUtilities import sims_clean_up
@@ -18,12 +20,15 @@ from lsst.sims.catUtils.utils import TestVariabilityMixin
 
 from lsst.sims.catUtils.mixins import Variability, reset_agn_lc_cache
 
+VARIABILITY_DB = 'VariabilityTestDatabase.db'
+ROOT = os.path.abspath(os.path.dirname(__file__))
+
 
 def setup_module(module):
     lsst.utils.tests.init()
 
 
-def makeRRlyTable(size=100, **kwargs):
+def makeRRlyTable(size=100, database=VARIABILITY_DB, **kwargs):
     """
     Make a test database to serve information to the rrlyrae test
     """
@@ -35,7 +40,7 @@ def makeRRlyTable(size=100, **kwargs):
     lcFiles = ['rrly_lc/RRc/959802_per.txt', 'rrly_lc/RRc/1078860_per.txt', 'rrly_lc/RRab/98874_per.txt',
                'rrly_lc/RRab/3879827_per.txt']
 
-    conn = sqlite3.connect('VariabilityTestDatabase.db')
+    conn = sqlite3.connect(database)
     c = conn.cursor()
     try:
         c.execute('''CREATE TABLE RRly
@@ -59,7 +64,7 @@ def makeRRlyTable(size=100, **kwargs):
     conn.close()
 
 
-def makeCepheidTable(size=100, **kwargs):
+def makeCepheidTable(size=100, database=VARIABILITY_DB, **kwargs):
     """
     Make a test database to serve information to the cepheid test
     """
@@ -72,7 +77,7 @@ def makeCepheidTable(size=100, **kwargs):
                'cepheid_lc/classical_shortPer_specfile', 'cepheid_lc/classical_shortPer_specfile',
                'cepheid_lc/popII_longPer_specfile', 'cepheid_lc/popII_shortPer_specfile']
 
-    conn = sqlite3.connect('VariabilityTestDatabase.db')
+    conn = sqlite3.connect(database)
     c = conn.cursor()
     try:
         c.execute('''CREATE TABLE cepheid
@@ -97,7 +102,7 @@ def makeCepheidTable(size=100, **kwargs):
     conn.close()
 
 
-def makeEbTable(size=100, **kwargs):
+def makeEbTable(size=100, database=VARIABILITY_DB, **kwargs):
     """
     Make a test database to serve information to the Eb test
     """
@@ -105,7 +110,7 @@ def makeEbTable(size=100, **kwargs):
     # a haphazard sample of eclipsing binary light curves
     lcFiles = ['eb_lc/EB.2294.inp', 'eb_lc/EB.1540.inp', 'eb_lc/EB.2801.inp']
 
-    conn = sqlite3.connect('VariabilityTestDatabase.db')
+    conn = sqlite3.connect(database)
     c = conn.cursor()
     try:
         c.execute('''CREATE TABLE eb
@@ -130,7 +135,7 @@ def makeEbTable(size=100, **kwargs):
     conn.close()
 
 
-def makeMicrolensingTable(size=100, **kwargs):
+def makeMicrolensingTable(size=100, database=VARIABILITY_DB, **kwargs):
     """
     Make a test database to serve information to the microlensing test
     """
@@ -140,7 +145,7 @@ def makeMicrolensingTable(size=100, **kwargs):
 
     # there are two microlensing methods; they should be equivalent
     method = ['applyMicrolensing', 'applyMicrolens']
-    conn = sqlite3.connect('VariabilityTestDatabase.db')
+    conn = sqlite3.connect(database)
     c = conn.cursor()
     try:
         c.execute('''CREATE TABLE microlensing
@@ -165,7 +170,7 @@ def makeMicrolensingTable(size=100, **kwargs):
     conn.close()
 
 
-def makeBHMicrolensingTable(size=100, **kwargs):
+def makeBHMicrolensingTable(size=100, database=VARIABILITY_DB, **kwargs):
     """
     Make a test database to serve information to the BHmicrolensing test
     """
@@ -179,7 +184,7 @@ def makeBHMicrolensingTable(size=100, **kwargs):
                'microlens/bh_binary_source/lc_14_25_4000_8000_0_phi1.09_0.005_100',
                'microlens/bh_binary_source/lc_14_25_75_8000_0_tets2.09_0.005_316']
 
-    conn = sqlite3.connect('VariabilityTestDatabase.db')
+    conn = sqlite3.connect(database)
     c = conn.cursor()
     try:
         c.execute('''CREATE TABLE bhmicrolensing
@@ -203,7 +208,7 @@ def makeBHMicrolensingTable(size=100, **kwargs):
     conn.close()
 
 
-def makeAmcvnTable(size=100, **kwargs):
+def makeAmcvnTable(size=100, database=VARIABILITY_DB, **kwargs):
     """
     Make a test database to serve information to the AMCVN test
     """
@@ -211,7 +216,7 @@ def makeAmcvnTable(size=100, **kwargs):
     # a haphazard sample of white dwarf SEDs
     sedFiles = ['bergeron_He_4750_70.dat_4950', 'bergeron_50000_85.dat_54000']
 
-    conn = sqlite3.connect('VariabilityTestDatabase.db')
+    conn = sqlite3.connect(database)
     c = conn.cursor()
     try:
         c.execute('''CREATE TABLE amcvn
@@ -249,14 +254,14 @@ def makeAmcvnTable(size=100, **kwargs):
     conn.close()
 
 
-def makeAgnTable(size=100, **kwargs):
+def makeAgnTable(size=100, database=VARIABILITY_DB, **kwargs):
     """
     Make a test database to serve information to the microlensing test
     """
 
     # a haphazard sample of galaxy SEDs
     sedFiles = ['Exp.31E06.0005Z.spec', 'Inst.79E06.1Z.spec', 'Const.50E07.0005Z.spec']
-    conn = sqlite3.connect('VariabilityTestDatabase.db')
+    conn = sqlite3.connect(database)
     c = conn.cursor()
     try:
         c.execute('''CREATE TABLE agn
@@ -301,7 +306,7 @@ def makeAgnTable(size=100, **kwargs):
     conn.close()
 
 
-def makeHybridTable(size=100, **kwargs):
+def makeHybridTable(size=100, database='VariabilityTestDatabase.db', **kwargs):
     """
     Make a test database that contains a mix of Cepheid variables
     and 'testVar' variables (variables that use the applySineVar
@@ -316,7 +321,7 @@ def makeHybridTable(size=100, **kwargs):
                'cepheid_lc/classical_shortPer_specfile', 'cepheid_lc/classical_shortPer_specfile',
                'cepheid_lc/popII_longPer_specfile', 'cepheid_lc/popII_shortPer_specfile']
 
-    conn = sqlite3.connect('VariabilityTestDatabase.db')
+    conn = sqlite3.connect(database)
     c = conn.cursor()
     try:
         c.execute('''CREATE TABLE hybrid
@@ -355,7 +360,7 @@ def makeHybridTable(size=100, **kwargs):
 
 class variabilityDB(CatalogDBObject):
     driver = 'sqlite'
-    database = 'VariabilityTestDatabase.db'
+    database = VARIABILITY_DB
     idColKey = 'varsimobjid'
     columns = [('id', 'varsimobjid', int),
                ('sedFilename', 'sedfilename', str, 40),
@@ -460,19 +465,19 @@ class VariabilityTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        if os.path.exists('VariabilityTestDatabase.db'):
-            os.unlink('VariabilityTestDatabase.db')
+        cls.scratch_dir = tempfile.mkdtemp(dir=ROOT, prefix='VariabilityTest-')
+        cls.variability_db = os.path.join(cls.scratch_dir, VARIABILITY_DB)
 
     @classmethod
     def tearDownClass(cls):
         sims_clean_up()
-        if os.path.exists('VariabilityTestDatabase.db'):
-            os.unlink('VariabilityTestDatabase.db')
+        if os.path.exists(cls.variability_db):
+            os.unlink(cls.variability_db)
+        if os.path.exists(cls.scratch_dir):
+            shutil.rmtree(cls.scratch_dir)
 
     def setUp(self):
         self.obs_metadata = ObservationMetaData(mjd=52000.0)
-        self.scratch_dir = os.path.join(getPackageDir('sims_catUtils'),
-                                        'tests', 'scratchSpace')
 
     def tearDown(self):
         del self.obs_metadata
@@ -494,7 +499,7 @@ class VariabilityTest(unittest.TestCase):
 
         control_dir = os.path.join(getPackageDir('sims_catUtils'),
                                    'tests', 'testData')
-        control_name = cat_name.split('/')[-1]
+        _, control_name = os.path.split(cat_name)
         control_name = os.path.join(control_dir, control_name)
         with open(control_name, 'r') as control_file:
             control_lines = control_file.readlines()
@@ -516,35 +521,37 @@ class VariabilityTest(unittest.TestCase):
         methods from mixins.
         """
         cat_name = os.path.join(self.scratch_dir, 'hybridTestCatalog.dat')
-        makeHybridTable()
-        myDB = CatalogDBObject.from_objid('hybridTest')
+        makeHybridTable(database=self.variability_db)
+        myDB = CatalogDBObject.from_objid('hybridTest', database=self.variability_db)
         myCatalog = StellarVariabilityCatalogWithTest(myDB, obs_metadata=self.obs_metadata)
-        myCatalog.write_catalog(cat_name, chunk_size=1000)
 
+        myCatalog.write_catalog(cat_name, chunk_size=1000)
         self.verify_catalogs(cat_name)
+
         if os.path.exists(cat_name):
             os.unlink(cat_name)
 
         # make sure order of mixin inheritance does not matter
         myCatalog = OtherVariabilityCatalogWithTest(myDB, obs_metadata=self.obs_metadata)
         myCatalog.write_catalog(cat_name, chunk_size=1000)
-
         self.verify_catalogs(cat_name)
+
         if os.path.exists(cat_name):
             os.unlink(cat_name)
 
         # make sure that, if a catalog does not contain a variability method,
         # an error is thrown; verify that it contains the correct error message
         myCatalog = StellarVariabilityCatalog(myDB, obs_metadata=self.obs_metadata)
+
         with self.assertRaises(RuntimeError) as context:
             myCatalog.write_catalog(cat_name)
+
+        if os.path.exists(cat_name):
+            os.unlink(cat_name)
 
         expectedMessage = "Your InstanceCatalog does not contain a variability method"
         expectedMessage += " corresponding to 'testVar'"
         self.assertEqual(context.exception.args[0], expectedMessage)
-
-        if os.path.exists(cat_name):
-            os.unlink(cat_name)
 
     def testApplyVariabilityWithManyMJD(self):
         """
@@ -553,8 +560,8 @@ class VariabilityTest(unittest.TestCase):
         the expected result out.
         """
 
-        makeHybridTable()
-        hybrid_db = hybridDB()
+        makeHybridTable(database=self.variability_db)
+        hybrid_db = hybridDB(database=self.variability_db)
         hybrid_cat = StellarVariabilityCatalogWithTest(hybrid_db, obs_metadata=self.obs_metadata,
                                                        column_outputs=['varParamStr'])
         rng = np.random.RandomState(88)
@@ -601,8 +608,8 @@ class VariabilityTest(unittest.TestCase):
 
     def testRRlyrae(self):
         cat_name = os.path.join(self.scratch_dir, 'rrlyTestCatalog.dat')
-        makeRRlyTable()
-        myDB = CatalogDBObject.from_objid('rrlyTest')
+        makeRRlyTable(database=self.variability_db)
+        myDB = CatalogDBObject.from_objid('rrlyTest', database=self.variability_db)
         myCatalog = StellarVariabilityCatalog(myDB, obs_metadata=self.obs_metadata)
         myCatalog.write_catalog(cat_name, chunk_size=1000)
 
@@ -612,8 +619,8 @@ class VariabilityTest(unittest.TestCase):
 
     def testCepheids(self):
         cat_name = os.path.join(self.scratch_dir, 'cepheidTestCatalog.dat')
-        makeCepheidTable()
-        myDB = CatalogDBObject.from_objid('cepheidTest')
+        makeCepheidTable(database=self.variability_db)
+        myDB = CatalogDBObject.from_objid('cepheidTest', database=self.variability_db)
         myCatalog = StellarVariabilityCatalog(myDB, obs_metadata=self.obs_metadata)
         myCatalog.write_catalog(cat_name, chunk_size=1000)
 
@@ -623,8 +630,8 @@ class VariabilityTest(unittest.TestCase):
 
     def testEb(self):
         cat_name = os.path.join(self.scratch_dir, 'ebTestCatalog.dat')
-        makeEbTable()
-        myDB = CatalogDBObject.from_objid('ebTest')
+        makeEbTable(database=self.variability_db)
+        myDB = CatalogDBObject.from_objid('ebTest', database=self.variability_db)
         myCatalog = StellarVariabilityCatalog(myDB, obs_metadata=self.obs_metadata)
         myCatalog.write_catalog(cat_name, chunk_size=1000)
 
@@ -641,8 +648,8 @@ class VariabilityTest(unittest.TestCase):
         # so that is what we will test.
 
         cat_name = os.path.join(self.scratch_dir, 'microlensTestCatalog.dat')
-        makeMicrolensingTable()
-        myDB = CatalogDBObject.from_objid('microlensTest')
+        makeMicrolensingTable(database=self.variability_db)
+        myDB = CatalogDBObject.from_objid('microlensTest', database=self.variability_db)
         myCatalog = StellarVariabilityCatalog(myDB, obs_metadata=self.obs_metadata)
         myCatalog.write_catalog(cat_name, chunk_size=1000)
 
@@ -659,8 +666,8 @@ class VariabilityTest(unittest.TestCase):
         # so that is what we will test.
 
         cat_name = os.path.join(self.scratch_dir, 'bhmicrolensTestCatalog.dat')
-        makeBHMicrolensingTable()
-        myDB = CatalogDBObject.from_objid('bhmicrolensTest')
+        makeBHMicrolensingTable(database=self.variability_db)
+        myDB = CatalogDBObject.from_objid('bhmicrolensTest', database=self.variability_db)
         myCatalog = StellarVariabilityCatalog(myDB, obs_metadata=self.obs_metadata)
         myCatalog.write_catalog(cat_name, chunk_size=1000)
 
@@ -677,8 +684,8 @@ class VariabilityTest(unittest.TestCase):
         # so that is what we will test.
 
         cat_name = os.path.join(self.scratch_dir, 'amcvnTestCatalog.dat')
-        makeAmcvnTable()
-        myDB = CatalogDBObject.from_objid('amcvnTest')
+        makeAmcvnTable(database=self.variability_db)
+        myDB = CatalogDBObject.from_objid('amcvnTest', database=self.variability_db)
         myCatalog = StellarVariabilityCatalog(myDB, obs_metadata=self.obs_metadata)
         myCatalog.write_catalog(cat_name, chunk_size=1000)
 
@@ -689,8 +696,8 @@ class VariabilityTest(unittest.TestCase):
     def testAgn(self):
 
         cat_name = os.path.join(self.scratch_dir, 'agnTestCatalog.dat')
-        makeAgnTable()
-        myDB = CatalogDBObject.from_objid('agnTest')
+        makeAgnTable(database=self.variability_db)
+        myDB = CatalogDBObject.from_objid('agnTest', database=self.variability_db)
         myCatalog = GalaxyVariabilityCatalog(myDB, obs_metadata=self.obs_metadata)
         myCatalog.write_catalog(cat_name, chunk_size=1000)
 


### PR DESCRIPTION
This is a work in progress. Not ready for release.

The main thrust is to use temporary file names and temporary scratch space so that multiple processes can run tests from the same class. This work is similar to that in lsst/sims_catalogs#13