### PR TITLE
U/danielsf/debug/connection tests

### DIFF
--- a/python/lsst/sims/catUtils/baseCatalogModels/SsmModels.py
+++ b/python/lsst/sims/catUtils/baseCatalogModels/SsmModels.py
@@ -183,6 +183,13 @@ class MBAObj(SolarSystemObj):
     """
     ssmtable = 'fSSMMBABase'
 
+    # since the MBA tables have been updated, we need to include a testObservationMetaData
+    # that had an mjd>=59580.0, since that is the new time range for the simulated
+    # LSST survey
+    testObservationMetaData = ObservationMetaData(boundType = 'circle',
+                                                  pointingRA = 0.0, pointingDec = 0.0,
+                                                  boundLength = 0.5, mjd=59590., bandpassName='r', m5=22.0)
+
 
 class MiscSolarSystemObj(SolarSystemObj):
     """

--- a/python/lsst/sims/catUtils/mixins/PhotometryMixin.py
+++ b/python/lsst/sims/catUtils/mixins/PhotometryMixin.py
@@ -181,7 +181,7 @@ class PhotometryBase(object):
             self.ssm_random_seeded = True
         # Pre-generate random numbers, if desired and not previously done.
         if pre_generate_randoms and not hasattr(self, 'ssm_randoms'):
-            self.ssm_randoms = numpy.random.rand(12000000)
+            self.ssm_randoms = numpy.random.rand(14000000)
         # Calculate probability values to compare to completeness.
         if hasattr(self, 'ssm_randoms'):
             # Grab the random numbers from self.randoms.

--- a/tests/testAllObjects.py
+++ b/tests/testAllObjects.py
@@ -7,6 +7,8 @@ import numpy as np
 import sys
 import traceback
 import unittest
+import tempfile
+import shutil
 import lsst.utils.tests
 
 from lsst.utils import getPackageDir
@@ -32,8 +34,11 @@ class basicAccessTest(unittest.TestCase):
     longMessage = True
 
     def testObjects(self):
-        catName = os.path.join(getPackageDir('sims_catUtils'), 'tests', 'scratchSpace',
-                               'testObjectsCat.txt')
+        catDir = tempfile.mkdtemp('basicAccessTest_testObjects')
+        if not os.path.exists(catDir):
+            os.mkdir(catDir)
+        catName = tempfile.mktemp(prefix='basicAccessTest_testObjects',
+                                  dir=catDir, suffix='.txt')
         ct_connected = 0
         ct_failed_connection = 0
         list_of_failures = []
@@ -104,6 +109,9 @@ class basicAccessTest(unittest.TestCase):
                 if os.path.exists(catName):
                     os.unlink(catName)
 
+        if os.path.exists(catDir):
+            shutil.rmtree(catDir)
+
         self.assertEqual(len(list_of_failures), ct_failed_connection)
 
         print('\n================')
@@ -118,8 +126,11 @@ class basicAccessTest(unittest.TestCase):
 
     def testObsCat(self):
         objname = 'wdstars'
-        catName = os.path.join(getPackageDir('sims_catUtils'), 'tests', 'scratchSpace',
-                               'testObsCat.txt')
+        catDir = tempfile.mkdtemp('basicAccessTest_testObsCat')
+        if not os.path.exists(catDir):
+            os.mkdir(catDir)
+        catName = tempfile.mktemp(prefix='basicAccessTest_testObsCat',
+                                  dir=catDir, suffix='.txt')
 
         try:
             dbobj = CatalogDBObject.from_objid(objname)
@@ -139,6 +150,8 @@ class basicAccessTest(unittest.TestCase):
             finally:
                 if os.path.exists(catName):
                     os.unlink(catName)
+                if os.path.exists(catDir):
+                    shutil.rmtree(catDir)
 
             print('\ntestObsCat successfully connected to fatboy')
 
@@ -152,6 +165,9 @@ class basicAccessTest(unittest.TestCase):
 
                 print('\ntestObsCat failed to connect to fatboy')
                 print('Sometimes that happens.  Do not worry.')
+
+                if os.path.exists(catDir):
+                    shutil.rmtree(catDir)
 
                 pass
             else:

--- a/tests/testAllObjects.py
+++ b/tests/testAllObjects.py
@@ -48,7 +48,7 @@ class basicAccessTest(unittest.TestCase):
             except:
                 trace = traceback.extract_tb(sys.exc_info()[2], limit=20)
                 msg = sys.exc_info()[1].args[0]
-                if 'Failed to connect' in msg or failedOnFatboy(trace):
+                if 'Failed to connect' in str(msg) or failedOnFatboy(trace):
 
                     # if the exception was due to a failed connection
                     # to fatboy, ignore it
@@ -145,7 +145,7 @@ class basicAccessTest(unittest.TestCase):
         except:
             trace = traceback.extract_tb(sys.exc_info()[2], limit=20)
             msg = sys.exc_info()[1].args[0]
-            if 'Failed to connect' in msg or failedOnFatboy(trace):
+            if 'Failed to connect' in str(msg) or failedOnFatboy(trace):
 
                 # if the exception was because of a failed connection
                 # to fatboy, ignore it.
@@ -171,7 +171,7 @@ class basicAccessTest(unittest.TestCase):
             except:
                 trace = traceback.extract_tb(sys.exc_info()[2], limit=20)
                 msg = sys.exc_info()[1].args[0]
-                if 'Failed to connect' in msg or failedOnFatboy(trace):
+                if 'Failed to connect' in str(msg) or failedOnFatboy(trace):
 
                     # if the exception was due to a failed connection
                     # to fatboy, ignore it
@@ -220,7 +220,7 @@ class basicAccessTest(unittest.TestCase):
             except:
                 trace = traceback.extract_tb(sys.exc_info()[2], limit=20)
                 msg = sys.exc_info()[1].args[0]
-                if 'Failed to connect' in msg or failedOnFatboy(trace):
+                if 'Failed to connect' in str(msg) or failedOnFatboy(trace):
 
                     # if the exception was due to a failed connection
                     # to fatboy, ignore it
@@ -283,7 +283,7 @@ class basicAccessTest(unittest.TestCase):
         except:
             trace = traceback.extract_tb(sys.exc_info()[2], limit=20)
             msg = sys.exc_info()[1].args[0]
-            if 'Failed to connect' in msg or failedOnFatboy(trace):
+            if 'Failed to connect' in str(msg) or failedOnFatboy(trace):
 
                 # if the exception was due to a failed connection
                 # to fatboy, ignore it

--- a/tests/testCompoundCatalogs.py
+++ b/tests/testCompoundCatalogs.py
@@ -55,6 +55,8 @@ class StarCatalog(InstanceCatalog):
                       'variabilityParameters', 'sedFilename']
 
 
+ROOT = os.path.abspath(os.path.dirname(__file__))
+
 class CompoundCatalogTest(unittest.TestCase):
 
     def setUp(self):

--- a/tests/testSSM_Diasources.py
+++ b/tests/testSSM_Diasources.py
@@ -106,7 +106,10 @@ class createSSMSourceCatalogsTest(unittest.TestCase):
                 # But moving objects databases are not currently complete for all years.
                 # Push forward to night=747.
                 # (note that we need the phosim dictionary as well)
-                newMJD = obsMeta.mjd.TAI + (747 - 20)
+
+                newMJD = 59590.2  # this MJD is artificially chosen to be in the
+                                  # time span of the new baseline simulated survey
+
                 phoSimMetaDict = {'exptime': [30]}
                 obs = ObservationMetaData(mjd=newMJD,
                                           pointingRA=obsMeta.pointingRA,

--- a/tests/testSSM_Diasources.py
+++ b/tests/testSSM_Diasources.py
@@ -71,6 +71,8 @@ class ssmCatCamera(ssmCat):
 
 class createSSMSourceCatalogsTest(unittest.TestCase):
 
+    longMessage = True
+
     @classmethod
     def tearDownClass(cls):
         sims_clean_up()
@@ -130,7 +132,8 @@ class createSSMSourceCatalogsTest(unittest.TestCase):
                         # verify that we did not write an empty catalog
                         with open(output_cat, 'r') as input_file:
                             lines = input_file.readlines()
-                        self.assertGreater(len(lines), 1)
+                        msg = 'MJD is %.3f' % obs.mjd.TAI
+                        self.assertGreater(len(lines), 1, msg=msg)
                 except:
                     # This is because the solar system object 'tables'
                     # don't actually connect to tables on fatboy; they just


### PR DESCRIPTION
Several small changes have left us in a state where, if you can actually connect to fatboy and run the tests of those connections, you will get unit test failures.  We did not notice this because Jenkins cannot connect to fatboy and automatically skips the offending tests.  Unfortunately, the alertSim team develops on a whitelisted machine which can connect to fatboy, meaning that installing/updating the stack triggers those tests and causes failures.  This PR fixes those tests.  In order to exercise the changes, you will need to run the unit tests while a tunnel to fatboy is open (it is not enough to be on campus and thus have access to fatboy directly; the tests assume you are using the ssh tunnel through port 51433).

I am sending you this pull request because some of the changes required touching the moving object sims, updating them to reflect our updated MBA tables on fatboy.