### PR TITLE
U/danielsf/fix/focal/plane

### DIFF
--- a/python/lsst/sims/catUtils/mixins/AstrometryMixin.py
+++ b/python/lsst/sims/catUtils/mixins/AstrometryMixin.py
@@ -12,6 +12,8 @@ from lsst.sims.utils import _pupilCoordsFromObserved
 from lsst.sims.utils import rotationMatrixFromVectors
 from lsst.sims.coordUtils.CameraUtils import chipNameFromPupilCoords, pixelCoordsFromPupilCoords
 from lsst.sims.coordUtils.LsstCameraUtils import chipNameFromPupilCoordsLSST
+from lsst.sims.coordUtils.LsstCameraUtils import pixelCoordsFromPupilCoordsLSST
+from lsst.sims.coordUtils.LsstCameraUtils import focalPlaneCoordsFromPupilCoordsLSST
 from lsst.sims.coordUtils.CameraUtils import focalPlaneCoordsFromPupilCoords
 
 from lsst.sims.catUtils.mixins.PhoSimSupport import _FieldRotator
@@ -110,6 +112,24 @@ class CameraCoordsLSST(CameraCoords):
 
         return chipNameFromPupilCoordsLSST(xPupil, yPupil,
                                            allow_multiple_chips=self.allow_multiple_chips)
+
+    @compound('xPix', 'yPix')
+    def get_pixelCoordinates(self):
+        """Get the pixel positions (or nan if not on a chip) for all objects in the catalog"""
+        xPupil, yPupil = (self.column_by_name('x_pupil'), self.column_by_name('y_pupil'))
+        chipNameList = self.column_by_name('chipName')
+        if len(xPupil) == 0:
+            return np.array([[],[]])
+        return pixelCoordsFromPupilCoordsLSST(xPupil, yPupil, chipName=chipNameList,
+                                              band=self.obs_metadata.bandpass)
+
+    @compound('xFocalPlane', 'yFocalPlane')
+    def get_focalPlaneCoordinates(self):
+        """Get the focal plane coordinates for all objects in the catalog."""
+        xPupil, yPupil = (self.column_by_name('x_pupil'), self.column_by_name('y_pupil'))
+        if len(xPupil) == 0:
+            return np.array([[],[]])
+        return focalPlaneCoordsFromPupilCoords(xPupil, yPupil, band=self.obs_metadata.bandpass)
 
 
 class AstrometryGalaxies(AstrometryBase):

--- a/python/lsst/sims/catUtils/utils/alertDataGenerator.py
+++ b/python/lsst/sims/catUtils/utils/alertDataGenerator.py
@@ -14,8 +14,7 @@ from lsst.sims.utils import arcsecFromRadians
 from lsst.sims.catUtils.utils import _baseLightCurveCatalog
 from lsst.sims.utils import _pupilCoordsFromRaDec
 from lsst.sims.coordUtils import chipNameFromPupilCoordsLSST
-from lsst.sims.coordUtils import pixelCoordsFromPupilCoords
-from lsst.sims.coordUtils import lsst_camera
+from lsst.sims.coordUtils import pixelCoordsFromPupilCoordsLSST
 
 from lsst.sims.catalogs.decorators import compound, cached
 from lsst.sims.photUtils import BandpassDict, Sed, calcSNR_m5
@@ -310,9 +309,9 @@ class _baseAlertCatalog(PhotometryBase, CameraCoordsLSST, _baseLightCurveCatalog
         xpup = self.column_by_name('x_pupil')
         ypup = self.column_by_name('y_pupil')
         chip_name = self.column_by_name('chipName')
-        xpix, ypix = pixelCoordsFromPupilCoords(xpup, ypup, chipName=chip_name,
-                                                camera=lsst_camera(),
-                                                includeDistortion=True)
+        xpix, ypix = pixelCoordsFromPupilCoordsLSST(xpup, ypup, chipName=chip_name,
+                                                    band=self.obs_metadata.bandpass,
+                                                    includeDistortion=True)
         return np.array([xpix, ypix])
 
     @compound('delta_umag', 'delta_gmag', 'delta_rmag',

--- a/tests/testPhoSimAstrometry.py
+++ b/tests/testPhoSimAstrometry.py
@@ -40,6 +40,7 @@ from lsst.sims.catUtils.exampleCatalogDefinitions import DefaultPhoSimHeaderMap
 from lsst.sims.utils import angularSeparation
 from lsst.sims.utils import _angularSeparation,arcsecFromRadians
 
+from lsst.sims.coordUtils import clean_up_lsst_camera
 
 ROOT = os.path.abspath(os.path.dirname(__file__))
 
@@ -151,12 +152,11 @@ class PhoSimAstrometryTestCase(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        if hasattr(lsst_camera, '_lsst_camera'):
-            del lsst_camera._lsst_camera
-
         sims_clean_up()
         if os.path.exists(cls.db_name):
             os.unlink(cls.db_name)
+
+        clean_up_lsst_camera()
 
     def test_stellar_astrometry_radians(self):
         """

--- a/tests/test_alertDataGenerator.py
+++ b/tests/test_alertDataGenerator.py
@@ -35,6 +35,10 @@ from lsst.sims.catUtils.mixins import Variability
 from lsst.sims.catalogs.definitions import InstanceCatalog
 from lsst.sims.catalogs.decorators import compound, cached
 
+from lsst.sims.coordUtils import focalPlaneCoordsFromPupilCoordsLSST
+from lsst.sims.coordUtils import pupilCoordsFromFocalPlaneCoordsLSST
+from lsst.sims.coordUtils import chipNameFromPupilCoordsLSST
+
 ROOT = os.path.abspath(os.path.dirname(__file__))
 
 
@@ -202,6 +206,14 @@ class AlertDataGeneratorTestCase(unittest.TestCase):
         for file_name in os.listdir(cls.output_dir):
             os.unlink(os.path.join(cls.output_dir, file_name))
         shutil.rmtree(cls.output_dir)
+
+        if hasattr(focalPlaneCoordsFromPupilCoordsLSST,'_z_fitter'):
+            del focalPlaneCoordsFromPupilCoordsLSST._z_fitter
+        if hasattr(pupilCoordsFromFocalPlaneCoordsLSST, '_z_fitter'):
+            del pupilCoordsFromFocalPlaneCoordsLSST._z_fitter
+        if hasattr(chipNameFromPupilCoordsLSST, '_detector_arr'):
+            del chipNameFromPupilCoordsLSST._detector_arr
+
         if hasattr(lsst_camera, '_lsst_camera'):
             del lsst_camera._lsst_camera
         attr_list = list(chipNameFromPupilCoordsLSST.__dict__.keys())
@@ -425,7 +437,8 @@ class AlertDataGeneratorTestCase(unittest.TestCase):
                                                  pm_dec=self.pmdec_truth[obj_dex],
                                                  parallax=self.px_truth[obj_dex],
                                                  v_rad=self.vrad_truth[obj_dex],
-                                                 obs_metadata=obs)
+                                                 obs_metadata=obs,
+                                                 band=obs.bandpass)
 
                 chipnum = int(chipname.replace('R', '').replace('S', '').
                               replace(' ', '').replace(';', '').replace(',', '').
@@ -438,7 +451,8 @@ class AlertDataGeneratorTestCase(unittest.TestCase):
                                                       pm_dec=self.pmdec_truth[obj_dex],
                                                       parallax=self.px_truth[obj_dex],
                                                       v_rad=self.vrad_truth[obj_dex],
-                                                      obs_metadata=obs)
+                                                      obs_metadata=obs,
+                                                      band=obs.bandpass)
 
                 self.assertAlmostEqual(alert_data['xPix'][i_obj], xpix, 4)
                 self.assertAlmostEqual(alert_data['yPix'][i_obj], ypix, 4)

--- a/tests/test_alertDataGenerator.py
+++ b/tests/test_alertDataGenerator.py
@@ -39,6 +39,8 @@ from lsst.sims.coordUtils import focalPlaneCoordsFromPupilCoordsLSST
 from lsst.sims.coordUtils import pupilCoordsFromFocalPlaneCoordsLSST
 from lsst.sims.coordUtils import chipNameFromPupilCoordsLSST
 
+from lsst.sims.coordUtils import clean_up_lsst_camera
+
 ROOT = os.path.abspath(os.path.dirname(__file__))
 
 
@@ -207,19 +209,7 @@ class AlertDataGeneratorTestCase(unittest.TestCase):
             os.unlink(os.path.join(cls.output_dir, file_name))
         shutil.rmtree(cls.output_dir)
 
-        if hasattr(focalPlaneCoordsFromPupilCoordsLSST,'_z_fitter'):
-            del focalPlaneCoordsFromPupilCoordsLSST._z_fitter
-        if hasattr(pupilCoordsFromFocalPlaneCoordsLSST, '_z_fitter'):
-            del pupilCoordsFromFocalPlaneCoordsLSST._z_fitter
-        if hasattr(chipNameFromPupilCoordsLSST, '_detector_arr'):
-            del chipNameFromPupilCoordsLSST._detector_arr
-
-        if hasattr(lsst_camera, '_lsst_camera'):
-            del lsst_camera._lsst_camera
-        attr_list = list(chipNameFromPupilCoordsLSST.__dict__.keys())
-        for attr in attr_list:
-            chipNameFromPupilCoordsLSST.__delattr__(attr)
-        gc.collect()
+        clean_up_lsst_camera()
 
     def test_alert_data_generation(self):
 

--- a/tests/test_avroAlertGenerator.py
+++ b/tests/test_avroAlertGenerator.py
@@ -30,6 +30,8 @@ from lsst.sims.catalogs.decorators import compound, cached
 from lsst.sims.catUtils.utils import AlertDataGenerator
 from lsst.sims.catUtils.utils import AvroAlertGenerator
 
+from lsst.sims.coordUtils import clean_up_lsst_camera
+
 _avro_is_installed = True
 try:
     from avro.io import DatumReader
@@ -267,12 +269,7 @@ class AvroAlertTestCase(unittest.TestCase):
         if os.path.exists(cls.input_dir):
             shutil.rmtree(cls.input_dir)
 
-        if hasattr(lsst_camera, '_lsst_camera'):
-            del lsst_camera._lsst_camera
-        attr_list = list(chipNameFromPupilCoordsLSST.__dict__.keys())
-        for attr in attr_list:
-            chipNameFromPupilCoordsLSST.__delattr__(attr)
-        gc.collect()
+        clean_up_lsst_camera()
 
     def setUp(self):
         self.alert_data_output_dir = tempfile.mkdtemp(dir=ROOT, prefix='avro_gen_output')


### PR DESCRIPTION
Update the `CameraUtils` mixins to reflect the new API for transforming from RA, Dec to pixel position on the LSST focal plane.

This branch requires branches of the same name in sims_data, sims_utils, and sims_coordUtils to run.