### PR TITLE
patch for new OpSim schema

### DIFF
--- a/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
+++ b/python/lsst/sims/catUtils/utils/ObservationMetaDataGenerator.py
@@ -129,7 +129,8 @@ class ObservationMetaDataGenerator(object):
                           'moonAz': ('moonAz', None, float),
                           'sunAz': ('sunAz', None, float),
                           'slewDist': ('slewDistance', None, float),
-                          'slewTime': ('slewTime', None, float)}
+                          'slewTime': ('slewTime', None, float),
+                          'note': ('note', None, str)}
 
         return interface_dict
 


### PR DESCRIPTION
Someone at TVS workshop had a failure because latest schema has a new `note` column. This seems to fix it.