### PR TITLE
Prevent None files being produced when creating SN instance catalogs.

### DIFF
--- a/python/lsst/sims/catUtils/mixins/sncat.py
+++ b/python/lsst/sims/catUtils/mixins/sncat.py
@@ -173,6 +173,7 @@ class SNFunctionality(InstanceCatalog, EBVmixin, CosmologyMixin, SNUniverse):
                     if self.mjdobs > snobject.maxtime() or self.mjdobs < snobject.mintime():
                         magNorms[i] = np.nan
                         fnames[i] = None
+                        continue
 
                 # SED in rest frame
                 sed = snobject.SNObjectSourceSED(time=self.mjdobs)


### PR DESCRIPTION
I think this quick fix prevents the `None` files with an empty SED from appearing when running instance catalog generation. The problem seemed to be that SNe outside the time range were still writing instance catalogs.