### PR TITLE
Added ignore_errors flag to rmtree

### DIFF
--- a/tests/testAllObjects.py
+++ b/tests/testAllObjects.py
@@ -11,10 +11,8 @@ import tempfile
 import shutil
 import lsst.utils.tests
 
-from lsst.utils import getPackageDir
 from lsst.sims.catalogs.db import CatalogDBObject
 from lsst.sims.catalogs.definitions import InstanceCatalog
-from lsst.sims.catUtils.exampleCatalogDefinitions import ObsStarCatalogBase
 from lsst.sims.catUtils.utils import failedOnFatboy
 # The following is to get the object ids in the registry
 import lsst.sims.catUtils.baseCatalogModels as bcm
@@ -110,7 +108,7 @@ class basicAccessTest(unittest.TestCase):
                     os.unlink(catName)
 
         if os.path.exists(catDir):
-            shutil.rmtree(catDir)
+            shutil.rmtree(catDir, ignore_errors=True)
 
         self.assertEqual(len(list_of_failures), ct_failed_connection)
 
@@ -151,7 +149,7 @@ class basicAccessTest(unittest.TestCase):
                 if os.path.exists(catName):
                     os.unlink(catName)
                 if os.path.exists(catDir):
-                    shutil.rmtree(catDir)
+                    shutil.rmtree(catDir, ignore_errors=True)
 
             print('\ntestObsCat successfully connected to fatboy')
 
@@ -167,7 +165,7 @@ class basicAccessTest(unittest.TestCase):
                 print('Sometimes that happens.  Do not worry.')
 
                 if os.path.exists(catDir):
-                    shutil.rmtree(catDir)
+                    shutil.rmtree(catDir, ignore_errors=True)
 
                 pass
             else:

--- a/tests/testAstrometryMixins.py
+++ b/tests/testAstrometryMixins.py
@@ -9,7 +9,6 @@ import tempfile
 import shutil
 import lsst.utils.tests
 
-from lsst.utils import getPackageDir
 from lsst.sims.utils.CodeUtilities import sims_clean_up
 from lsst.sims.catalogs.definitions import InstanceCatalog
 from lsst.sims.utils import ObservationMetaData, arcsecFromRadians
@@ -136,7 +135,7 @@ class astrometryUnitTest(unittest.TestCase):
         if os.path.exists(cls.galDBName):
             os.unlink(cls.galDBName)
         if os.path.exists(cls.scratch_dir):
-            shutil.rmtree(cls.scratch_dir)
+            shutil.rmtree(cls.scratch_dir, ignore_errors=True)
 
     def setUp(self):
         self.starDBObject = AstrometryTestStars(database=self.starDBName)

--- a/tests/testCompoundCatalogs.py
+++ b/tests/testCompoundCatalogs.py
@@ -3,7 +3,6 @@ import os
 import shutil
 import tempfile
 import lsst.utils.tests
-from lsst.utils import getPackageDir
 
 from lsst.sims.utils import ObservationMetaData
 from lsst.sims.catUtils.baseCatalogModels import (GalaxyBulgeObj, GalaxyDiskObj,
@@ -64,7 +63,7 @@ class CompoundCatalogTest(unittest.TestCase):
 
     def tearDown(self):
         if os.path.exists(self.baseDir):
-            shutil.rmtree(self.baseDir)
+            shutil.rmtree(self.baseDir, ignore_errors=True)
 
     @unittest.skipIf(not _testCompoundCatalogs_is_connected,
                      "We are not connected to fatboy")

--- a/tests/testDitherColumnDetection.py
+++ b/tests/testDitherColumnDetection.py
@@ -8,7 +8,6 @@ import tempfile
 import shutil
 
 import lsst.utils.tests
-from lsst.utils import getPackageDir
 from lsst.sims.catUtils.utils import ObservationMetaDataGenerator
 from lsst.sims.utils.CodeUtilities import sims_clean_up
 
@@ -32,7 +31,7 @@ class ObsMetaDataGenDitherTestClass(unittest.TestCase):
         if os.path.exists(cls.fake_db_name):
             os.unlink(cls.fake_db_name)
         if os.path.exists(cls.scratch_space):
-            shutil.rmtree(cls.scratch_space)
+            shutil.rmtree(cls.scratch_space, ignore_errors=True)
 
     @classmethod
     def setUpClass(cls):

--- a/tests/testFastLightCurveGenerator.py
+++ b/tests/testFastLightCurveGenerator.py
@@ -139,7 +139,7 @@ class FastStellar_stellar_lc_gen_case(unittest.TestCase):
         if os.path.exists(cls.mlt_lc_file_name):
             os.unlink(cls.mlt_lc_file_name)
         if os.path.exists(cls.scratchDir):
-            shutil.rmtree(cls.scratchDir)
+            shutil.rmtree(cls.scratchDir, ignore_errors=True)
 
     def test_fast_stellar_lc_gen(self):
 

--- a/tests/testLightCurveGenerator.py
+++ b/tests/testLightCurveGenerator.py
@@ -133,7 +133,7 @@ class StellarLightCurveTest(unittest.TestCase):
         if os.path.exists(cls.txt_name):
             os.unlink(cls.txt_name)
         if os.path.exists(cls.scratchDir):
-            shutil.rmtree(cls.scratchDir)
+            shutil.rmtree(cls.scratchDir, ignore_errors=True)
 
     def test_get_pointings(self):
         """

--- a/tests/testMLTflareModel.py
+++ b/tests/testMLTflareModel.py
@@ -130,7 +130,7 @@ class MLT_flare_test_case(unittest.TestCase):
             os.unlink(cls.db_name)
 
         if os.path.exists(cls.scratch_dir):
-            shutil.rmtree(cls.scratch_dir)
+            shutil.rmtree(cls.scratch_dir, ignore_errors=True)
 
     def test_flare_lc_failure(self):
         """
@@ -734,7 +734,7 @@ class MLT_flare_mixed_with_none_model_test_case(unittest.TestCase):
             os.unlink(cls.db_name)
 
         if os.path.exists(cls.scratch_dir):
-            shutil.rmtree(cls.scratch_dir)
+            shutil.rmtree(cls.scratch_dir, ignore_errors=True)
 
     def test_flare_magnitudes_mixed_with_none(self):
         """
@@ -998,7 +998,7 @@ class MLT_flare_mixed_with_dummy_model_test_case(unittest.TestCase):
             os.unlink(cls.dummy_lc_name)
 
         if os.path.exists(cls.scratch_dir):
-            shutil.rmtree(cls.scratch_dir)
+            shutil.rmtree(cls.scratch_dir, ignore_errors=True)
 
     def test_flare_magnitudes_mixed_with_dummy(self):
         """

--- a/tests/testPhoSimCatalogs.py
+++ b/tests/testPhoSimCatalogs.py
@@ -121,7 +121,7 @@ class PhoSimCatalogTest(unittest.TestCase):
     def tearDownClass(cls):
         sims_clean_up()
         if os.path.exists(cls.scratch_dir):
-            shutil.rmtree(cls.scratch_dir)
+            shutil.rmtree(cls.scratch_dir, ignore_errors=True)
 
     def setUp(self):
         self.tempDB = os.path.join(self.scratch_dir, 'PhoSimTestDatabase.db')

--- a/tests/testSN.py
+++ b/tests/testSN.py
@@ -427,7 +427,7 @@ class SNIaCatalog_tests(unittest.TestCase):
         if os.path.exists(cls.fullCatalog):
             os.unlink(cls.fullCatalog)
         if os.path.exists(cls.scratchDir):
-            shutil.rmtree(cls.scratchDir)
+            shutil.rmtree(cls.scratchDir, ignore_errors=True)
 
     def test_writingfullCatalog(self):
         """
@@ -658,7 +658,7 @@ class SNIaLightCurveTest(unittest.TestCase):
         if os.path.exists(cls.input_cat_name):
             os.unlink(cls.input_cat_name)
         if os.path.exists(cls.scratchDir):
-            shutil.rmtree(cls.scratchDir)
+            shutil.rmtree(cls.scratchDir, ignore_errors=True)
 
     def test_sne_light_curves(self):
         """

--- a/tests/testSetupRoutines.py
+++ b/tests/testSetupRoutines.py
@@ -143,7 +143,7 @@ class InstanceCatalogSetupUnittest(unittest.TestCase):
     def tearDownClass(cls):
         sims_clean_up()
         if os.path.exists(cls.scratch_dir):
-            shutil.rmtree(cls.scratch_dir)
+            shutil.rmtree(cls.scratch_dir, ignore_errors=True)
 
     def setUp(self):
         self.driver = 'sqlite'

--- a/tests/testUWGalaxyTileObj.py
+++ b/tests/testUWGalaxyTileObj.py
@@ -454,7 +454,7 @@ class GalaxyTileObjTestCase(unittest.TestCase):
 
         if os.path.exists(cat_name):
             os.unlink(cat_name)
-        shutil.rmtree(scratch_dir)
+        shutil.rmtree(scratch_dir, ignore_errors=True)
 
 
 class MemoryTestClass(lsst.utils.tests.MemoryTestCase):

--- a/tests/testVariabilityInfrastructure.py
+++ b/tests/testVariabilityInfrastructure.py
@@ -191,7 +191,7 @@ class VariabilityDesignTest(unittest.TestCase):
     def tearDownClass(cls):
         sims_clean_up()
         if os.path.exists(cls.scratch_dir):
-            shutil.rmtree(cls.scratch_dir)
+            shutil.rmtree(cls.scratch_dir, ignore_errors=True)
 
     def setUp(self):
         self.starDB = myTestStars(database=self.starDbName)

--- a/tests/testVariabilityMixins.py
+++ b/tests/testVariabilityMixins.py
@@ -474,7 +474,7 @@ class VariabilityTest(unittest.TestCase):
         if os.path.exists(cls.variability_db):
             os.unlink(cls.variability_db)
         if os.path.exists(cls.scratch_dir):
-            shutil.rmtree(cls.scratch_dir)
+            shutil.rmtree(cls.scratch_dir, ignore_errors=True)
 
     def setUp(self):
         self.obs_metadata = ObservationMetaData(mjd=52000.0)

--- a/tests/test_avroAlertGenerator.py
+++ b/tests/test_avroAlertGenerator.py
@@ -267,7 +267,7 @@ class AvroAlertTestCase(unittest.TestCase):
         if os.path.exists(cls.star_db_name):
             os.unlink(cls.star_db_name)
         if os.path.exists(cls.input_dir):
-            shutil.rmtree(cls.input_dir)
+            shutil.rmtree(cls.input_dir, ignore_errors=True)
 
     def setUp(self):
         self.alert_data_output_dir = tempfile.mkdtemp(dir=ROOT, prefix='avro_gen_output')
@@ -276,11 +276,11 @@ class AvroAlertTestCase(unittest.TestCase):
     def tearDown(self):
         for file_name in os.listdir(self.alert_data_output_dir):
             os.unlink(os.path.join(self.alert_data_output_dir, file_name))
-        shutil.rmtree(self.alert_data_output_dir)
+        shutil.rmtree(self.alert_data_output_dir, ignore_errors=True)
 
         for file_name in os.listdir(self.avro_out_dir):
             os.unlink(os.path.join(self.avro_out_dir, file_name))
-        shutil.rmtree(self.avro_out_dir)
+        shutil.rmtree(self.avro_out_dir, ignore_errors=True)
 
     def test_avro_alert_generation(self):
         dmag_cutoff = 0.005


### PR DESCRIPTION
Jenkins can sometimes fail to delete directories (see https://jira.lsstcorp.org/browse/DM-10300) and the fix is apparently to ignore the error in the deletion. When we create directories for tests, we use random temporary names that should always be empty directories -- so ignoring the deletion errors should not impact unit tests. 

